### PR TITLE
updates ua string fixture in tests -> v2.2.1-alpha.1. fixes #53

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -30,6 +30,8 @@ In order to create a release, the following should be completed in order.
    - sample/HelloWorld/composer.json
    - sample/Archiving/composer.json
    - README.md
+   - tests/OpenTok/OpenTokTest.php
+   - tests/OpenTok/ArchiveTest.php
 1. Commit the version number change with the message "Update to version x.x.x", substituting the new version number.
 1. Create a git tag: `git tag -a vx.x.x -m "Release vx.x.x"`
 1. Change the version number for future development by adding "-alpha.1" in each file, then make another commit with the

--- a/tests/OpenTok/ArchiveTest.php
+++ b/tests/OpenTok/ArchiveTest.php
@@ -104,7 +104,7 @@ class ArchiveTest extends PHPUnit_Framework_TestCase {
         // TODO: test the dynamically built User Agent string
         $userAgent = $request->getHeader('User-Agent');
         $this->assertNotEmpty($userAgent);
-        $this->assertStringStartsWith('OpenTok-PHP-SDK/dev-modernization', $userAgent->__toString());
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/2.2.1-alpha.1', $userAgent->__toString());
 
         // TODO: test the properties of the actual archive object
         $this->assertEquals('stopped', $this->archive->status);
@@ -147,7 +147,7 @@ class ArchiveTest extends PHPUnit_Framework_TestCase {
         // TODO: test the dynamically built User Agent string
         $userAgent = $request->getHeader('User-Agent');
         $this->assertNotEmpty($userAgent);
-        $this->assertStringStartsWith('OpenTok-PHP-SDK/dev-modernization', $userAgent->__toString());
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/2.2.1-alpha.1', $userAgent->__toString());
 
         $this->assertTrue($success);
         // TODO: assert that all properties of the archive object were cleared

--- a/tests/OpenTok/OpenTokTest.php
+++ b/tests/OpenTok/OpenTokTest.php
@@ -54,7 +54,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         // Assert
     }
 
-    public function testCreatesMediaRouterAndLocationSession()
+    public function testCreatesMediaRoutedAndLocationSession()
     {
         // Arrange
         $mock = new MockPlugin();
@@ -87,7 +87,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         // TODO: test the dynamically built User Agent string
         $userAgent = $request->getHeader('User-Agent');
         $this->assertNotEmpty($userAgent);
-        $this->assertStringStartsWith('OpenTok-PHP-SDK/dev-modernization', $userAgent->__toString());
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/2.2.1-alpha.1', $userAgent->__toString());
 
         $location = $request->getPostField('location');
         $this->assertEquals('12.34.56.78', $location);
@@ -136,7 +136,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         // TODO: test the dynamically built User Agent string
         $userAgent = $request->getHeader('User-Agent');
         $this->assertNotEmpty($userAgent);
-        $this->assertStringStartsWith('OpenTok-PHP-SDK/dev-modernization', $userAgent->__toString());
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/2.2.1-alpha.1', $userAgent->__toString());
 
         $p2p_preference = $request->getPostField('p2p.preference');
         $this->assertEquals('enabled', $p2p_preference);
@@ -314,7 +314,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         // TODO: test the dynamically built User Agent string
         $userAgent = $request->getHeader('User-Agent');
         $this->assertNotEmpty($userAgent);
-        $this->assertStringStartsWith('OpenTok-PHP-SDK/dev-modernization', $userAgent->__toString());
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/2.2.1-alpha.1', $userAgent->__toString());
 
         $body = json_decode($request->getBody());
         $this->assertEquals($sessionId, $body->sessionId);
@@ -360,7 +360,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         // TODO: test the dynamically built User Agent string
         $userAgent = $request->getHeader('User-Agent');
         $this->assertNotEmpty($userAgent);
-        $this->assertStringStartsWith('OpenTok-PHP-SDK/dev-modernization', $userAgent->__toString());
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/2.2.1-alpha.1', $userAgent->__toString());
 
         $this->assertInstanceOf('OpenTok\Archive', $archive);
         // TODO: test the properties of the actual archive object
@@ -400,7 +400,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         // TODO: test the dynamically built User Agent string
         $userAgent = $request->getHeader('User-Agent');
         $this->assertNotEmpty($userAgent);
-        $this->assertStringStartsWith('OpenTok-PHP-SDK/dev-modernization', $userAgent->__toString());
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/2.2.1-alpha.1', $userAgent->__toString());
 
         $this->assertInstanceOf('OpenTok\Archive', $archive);
         // TODO: test the properties of the actual archive object
@@ -442,7 +442,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         // TODO: test the dynamically built User Agent string
         $userAgent = $request->getHeader('User-Agent');
         $this->assertNotEmpty($userAgent);
-        $this->assertStringStartsWith('OpenTok-PHP-SDK/dev-modernization', $userAgent->__toString());
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/2.2.1-alpha.1', $userAgent->__toString());
 
         $this->assertTrue($success);
         // TODO: test the properties of the actual archive object
@@ -479,7 +479,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         // TODO: test the dynamically built User Agent string
         $userAgent = $request->getHeader('User-Agent');
         $this->assertNotEmpty($userAgent);
-        $this->assertStringStartsWith('OpenTok-PHP-SDK/dev-modernization', $userAgent->__toString());
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/2.2.1-alpha.1', $userAgent->__toString());
 
         $this->assertInstanceOf('OpenTok\ArchiveList', $archiveList);
         // TODO: test the properties of the actual archiveList object and its contained archive


### PR DESCRIPTION
also fixes a small spelling mistake in the name of a method
