### PR TITLE
Remove createdAt field from archive response validation schema.

### DIFF
--- a/src/OpenTok/Util/archive-schema.json
+++ b/src/OpenTok/Util/archive-schema.json
@@ -21,9 +21,6 @@
       "description": "An OpenTok Archive",
       "type": "object",
       "properties": {
-        "createdAt": {
-          "type" : "integer"
-        },
         "duration": {
           "type" : "integer",
           "minimum": 0


### PR DESCRIPTION
Remove createdAt field from archive response validation schema. As it type double and brings to fatal error when archiving started.