### PR TITLE
Fixed Variable Name

### DIFF
--- a/sample/Archiving/web/js/participant.js
+++ b/sample/Archiving/web/js/participant.js
@@ -2,7 +2,7 @@ var session = OT.initSession(sessionId),
     publisher = OT.initPublisher('publisher');
 
 session.connect(apiKey, token, function(error) {
-  if(err) {
+  if(error) {
     console.error(error.message);
     return;
   }


### PR DESCRIPTION
This was preventing multiple participants from being able to connect properly. Variable error was written as err.