### PR TITLE
Fix usage of abandoned Guzzle package in requirments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "php": ">=5.0.0",
-        "guzzle/guzzle": "~3.7",
+        "guzzlehttp/guzzle": "~3.7",
         "aoberoi/json-works": "~1.0",
         "firebase/php-jwt": "^3.0"
     },


### PR DESCRIPTION
I decided to change package name in order to keep ```composer update``` clean from warnings.

> Please see details on package home page:
> https://packagist.org/packages/guzzle/guzzle
> This package is abandoned and no longer maintained. The author suggests using the > guzzlehttp/guzzle package instead.

#### Update 
As I see in readme:
> This repository is for Guzzle 3.x. Guzzle 5.x, the new version of Guzzle, has been released and is  available at https://github.com/guzzle/guzzle. The documentation for Guzzle version 5+ can be found at http://guzzlephp.org.

Also there is difference in branch 3.* available versions, so I believe there is no real need to use new package for guzzle 3. 

Sorry for confusing.