### PR TITLE
add resolution parameter for archiving

### DIFF
--- a/src/OpenTok/Archive.php
+++ b/src/OpenTok/Archive.php
@@ -41,6 +41,9 @@ use OpenTok\Exception\ArchiveUnexpectedValueException;
 * For archives with the status "stopped" or "failed", this string describes the reason
 * the archive stopped (such as "maximum duration exceeded") or failed.
 *
+* @property string $resolution
+* The resolution of the archive.
+*
 * @property string $sessionId
 * The session ID of the OpenTok session associated with this archive.
 *
@@ -133,6 +136,7 @@ class Archive {
             case 'hasVideo':
             case 'hasAudio':
             case 'outputMode':
+            case 'resolution':
                 return $this->data[$name];
                 break;
             default:

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -292,10 +292,11 @@ class OpenTok {
             'name' => null,
             'hasVideo' => true,
             'hasAudio' => true,
-            'outputMode' => OutputMode::COMPOSED
+            'outputMode' => OutputMode::COMPOSED,
+            'resolution' => '640x480'
         );
         $options = array_merge($defaults, array_intersect_key($options, $defaults));
-        list($name, $hasVideo, $hasAudio, $outputMode) = array_values($options);
+        list($name, $hasVideo, $hasAudio, $outputMode, $resolution) = array_values($options);
 
         // validate arguments
         Validators::validateSessionId($sessionId);
@@ -303,6 +304,7 @@ class OpenTok {
         Validators::validateArchiveHasVideo($hasVideo);
         Validators::validateArchiveHasAudio($hasAudio);
         Validators::validateArchiveOutputMode($outputMode);
+        Validators::validateArchiveResolution($resolution);
 
         // make API call
         $archiveData = $this->client->startArchive($sessionId, $options);

--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -145,6 +145,12 @@ class Validators
             throw new InvalidArgumentException('Unknown output mode: '.print_r($outputMode, true));
         }
     }
+    public static function validateArchiveResolution($resolution)
+    {
+        if (!(is_string($resolution))) {
+            throw new InvalidArgumentException('The resolution must be a string: '.print_r($resolution, true));
+        }
+    }
     public static function validateArchiveId($archiveId)
     {
         if ( !is_string($archiveId) || preg_match(self::$guidRegEx, $archiveId) ) {

--- a/tests/OpenTok/ArchiveTest.php
+++ b/tests/OpenTok/ArchiveTest.php
@@ -43,7 +43,8 @@ class ArchiveTest extends PHPUnit_Framework_TestCase {
             'url' => null,
             'hasVideo' => false,
             'hasAudio' => true,
-            'outputMode' => 'composed'
+            'outputMode' => 'composed',
+            'resolution' => '640x480'
         );
 
         $this->archive = new Archive($this->archiveData, array(

--- a/tests/OpenTok/ArchiveTest.php
+++ b/tests/OpenTok/ArchiveTest.php
@@ -118,6 +118,7 @@ class ArchiveTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($this->archiveData['hasVideo'], $this->archive->hasVideo);
         $this->assertEquals($this->archiveData['hasAudio'], $this->archive->hasAudio);
         $this->assertEquals($this->archiveData['outputMode'], $this->archive->outputMode);
+        $this->assertEquals($this->archiveData['resolution'], $this->archive->resolution);
     }
 
     public function testStopsArchive()

--- a/tests/OpenTok/OpenTokTest.php
+++ b/tests/OpenTok/OpenTokTest.php
@@ -688,6 +688,102 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(OutputMode::INDIVIDUAL, $archive->outputMode);
     }
 
+    public function testStartsArchiveResolutionSD()
+    {
+        // Arrange
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'path' => 'v2/project/APIKEY/archive/session_resolution-sd'
+        ]]);
+
+        // This sessionId was generated using a different apiKey, but this method doesn't do any
+        // decoding to check, so its fine.
+        $sessionId = '2_MX44NTQ1MTF-flR1ZSBOb3YgMTIgMDk6NDA6NTkgUFNUIDIwMTN-MC43NjU0Nzh-';
+
+        // Act
+        $archive = $this->opentok->startArchive($sessionId, array(
+            'resolution' => '640x480'
+        ));
+
+        // Assert
+        $this->assertCount(1, $this->historyContainer);
+
+        $request = $this->historyContainer[0]['request'];
+        $this->assertEquals('POST', strtoupper($request->getMethod()));
+        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
+        $this->assertEquals('https', $request->getUri()->getScheme());
+
+        $contentType = $request->getHeaderLine('Content-Type');
+        $this->assertNotEmpty($contentType);
+        $this->assertEquals('application/json', $contentType);
+
+        $authString = $request->getHeaderLine('X-OPENTOK-AUTH');
+        $this->assertEquals(true, TestHelpers::validateOpenTokAuthHeader($this->API_KEY, $this->API_SECRET, $authString));
+
+        // TODO: test the dynamically built User Agent string
+        $userAgent = $request->getHeaderLine('User-Agent');
+        $this->assertNotEmpty($userAgent);
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/4.0.0', $userAgent);
+
+        $body = json_decode($request->getBody());
+        $this->assertEquals($sessionId, $body->sessionId);
+        $this->assertEquals('640x480', $body->resolution);
+
+        $this->assertInstanceOf('OpenTok\Archive', $archive);
+    }
+
+    public function testStartsArchiveResolutionHD()
+    {
+        // Arrange
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'path' => 'v2/project/APIKEY/archive/session_resolution-hd'
+        ]]);
+
+        // This sessionId was generated using a different apiKey, but this method doesn't do any
+        // decoding to check, so its fine.
+        $sessionId = '2_MX44NTQ1MTF-flR1ZSBOb3YgMTIgMDk6NDA6NTkgUFNUIDIwMTN-MC43NjU0Nzh-';
+
+        // Act
+        $archive = $this->opentok->startArchive($sessionId, array(
+            'resolution' => '1280x720'
+        ));
+
+        // Assert
+        $this->assertCount(1, $this->historyContainer);
+
+        $request = $this->historyContainer[0]['request'];
+        $this->assertEquals('POST', strtoupper($request->getMethod()));
+        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
+        $this->assertEquals('https', $request->getUri()->getScheme());
+
+        $contentType = $request->getHeaderLine('Content-Type');
+        $this->assertNotEmpty($contentType);
+        $this->assertEquals('application/json', $contentType);
+
+        $authString = $request->getHeaderLine('X-OPENTOK-AUTH');
+        $this->assertEquals(true, TestHelpers::validateOpenTokAuthHeader($this->API_KEY, $this->API_SECRET, $authString));
+
+        // TODO: test the dynamically built User Agent string
+        $userAgent = $request->getHeaderLine('User-Agent');
+        $this->assertNotEmpty($userAgent);
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/4.0.0', $userAgent);
+
+        $body = json_decode($request->getBody());
+        $this->assertEquals($sessionId, $body->sessionId);
+        $this->assertEquals('1280x720', $body->resolution);
+
+        $this->assertInstanceOf('OpenTok\Archive', $archive);
+    }
+
     public function testStopsArchive()
     {
         // Arrange

--- a/tests/OpenTok/OpenTokTest.php
+++ b/tests/OpenTok/OpenTokTest.php
@@ -727,7 +727,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         // TODO: test the dynamically built User Agent string
         $userAgent = $request->getHeaderLine('User-Agent');
         $this->assertNotEmpty($userAgent);
-        $this->assertStringStartsWith('OpenTok-PHP-SDK/4.0.0', $userAgent);
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/4.0.1-alpha.1', $userAgent);
 
         $body = json_decode($request->getBody());
         $this->assertEquals($sessionId, $body->sessionId);
@@ -775,7 +775,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         // TODO: test the dynamically built User Agent string
         $userAgent = $request->getHeaderLine('User-Agent');
         $this->assertNotEmpty($userAgent);
-        $this->assertStringStartsWith('OpenTok-PHP-SDK/4.0.0', $userAgent);
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/4.0.1-alpha.1', $userAgent);
 
         $body = json_decode($request->getBody());
         $this->assertEquals($sessionId, $body->sessionId);

--- a/tests/mock/v2/project/APIKEY/archive/session_resolution-hd
+++ b/tests/mock/v2/project/APIKEY/archive/session_resolution-hd
@@ -1,0 +1,13 @@
+{
+  "id" : "832641bf-5dbf-41a1-ad94-fea213e59a92",
+  "createdAt" : 1394321113584,
+  "duration" : 0,
+  "name" : null,
+  "partnerId" : 12345678,
+  "reason" : "",
+  "resolution" : "1280x720",
+  "sessionId" : "2_MX44NTQ1MTF-flR1ZSBOb3YgMTIgMDk6NDA6NTkgUFNUIDIwMTN-MC43NjU0Nzh-",
+  "size" : 0,
+  "status" : "started",
+  "url" : null
+}

--- a/tests/mock/v2/project/APIKEY/archive/session_resolution-sd
+++ b/tests/mock/v2/project/APIKEY/archive/session_resolution-sd
@@ -1,0 +1,13 @@
+{
+  "id" : "832641bf-5dbf-41a1-ad94-fea213e59a92",
+  "createdAt" : 1394321113584,
+  "duration" : 0,
+  "name" : null,
+  "partnerId" : 12345678,
+  "reason" : "",
+  "resolution" : "640x480",
+  "sessionId" : "2_MX44NTQ1MTF-flR1ZSBOb3YgMTIgMDk6NDA6NTkgUFNUIDIwMTN-MC43NjU0Nzh-",
+  "size" : 0,
+  "status" : "started",
+  "url" : null
+}


### PR DESCRIPTION
**What is this PR doing?**
Adds the `resolution` parameter for the `startArchive` function and allows developer to get the `resolution` information from an archive.

**How should this be manually tested?**
Clone this locally and start an archive with the `resolution` set to either `640x480` or `1280x720`.