### PR TITLE
Send options like maxDuration and resolution to startBroadcast

### DIFF
--- a/src/OpenTok/Broadcast.php
+++ b/src/OpenTok/Broadcast.php
@@ -87,6 +87,9 @@ class Broadcast {
             case 'partnerId':
             case 'sessionId':
             case 'broadcastUrls':
+            case 'status':
+            case 'maxDuration':
+            case 'resolution':
                 return $this->data[$name];
                 break;
             case 'hlsUrl':

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -504,7 +504,7 @@ class OpenTok {
         $defaults = array(
             'layout' => Layout::getBestFit()
         );
-        $options = array_merge($defaults, array_intersect_key($options, $defaults));
+        $options = array_merge($defaults, $options);
         list($layout) = array_values($options);
 
         // validate arguments

--- a/src/OpenTok/Util/Client.php
+++ b/src/OpenTok/Util/Client.php
@@ -280,13 +280,17 @@ class Client
             '/v2/project/'.$this->apiKey.'/broadcast'
         );
 
+        $optionsJson = [
+            'sessionId' => $sessionId,
+            'layout' => $options['layout']->jsonSerialize()
+        ];
+        unset($options['layout']);
+        $optionsJson = array_merge($optionsJson, $options);
+
         try {
             $response = $this->client->send($request, [
                 'debug' => $this->isDebug(),
-                'json' => [
-                    'sessionId' => $sessionId,
-                    'layout' => $options['layout']->jsonSerialize()
-                ]
+                'json' => $optionsJson
             ]);
             $broadcastJson = json_decode($response->getBody(), true);
         } catch (\Exception $e) {


### PR DESCRIPTION
Hi,  
  
When using the `startBroadcast` function, options are not taken into account because of this line :   
`$options = array_merge($defaults, array_intersect_key($options, $defaults));`  
which only take default var (layout).  

The idea is to create a broadcast with these parameters : 
```
$options = [
    'layout' => Layout::getPIP(),
    'maxDuration' => 10800, //3 hours
    'resolution' => '1280x720',
    'outputs' => [
        'rtmp' => [
            ...
        ]
    ]
];
```

"maxDuration" and "resolution" are new parameters from this documentation page :   
https://tokbox.com/developer/rest/#start_broadcast