### PR TITLE
Removing HHVM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
 - 5.6
 - 7.0
 - 7.1
-- hhvm-3.30
 before_script:
 - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
 - travis_retry composer install


### PR DESCRIPTION
Facebook will not support PHP syntax any higher than 5.6 as they focus on hacklang, so removing support for this in our SDK. 

This is also blocking new PRs coming through, and will impact future work as we update the SDK, so we need to remove it before any major work starts.