### PR TITLE
PHP 7.1 Upgrade and CS Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ dist: trusty
 sudo: required
 language: php
 php:
-- 5.6
-- 7.0
 - 7.1
+- 7.2
+- 7.3
+- 7.4
 before_script:
 - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
 - travis_retry composer install

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     },
     "require": {
         "php": "^7.1",
+        "ext-xml": "*",
         "johnstevenson/json-works": "~1.1",
         "firebase/php-jwt": "^5.0",
         "guzzlehttp/guzzle": "~6.0"

--- a/composer.json
+++ b/composer.json
@@ -34,12 +34,19 @@
         "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7",
+        "phpunit/phpunit": "^7.4",
+        "php-http/mock-client": "^0.3.0",
+        "estahn/phpunit-json-assertions": "^3.0.0",
+        "squizlabs/php_codesniffer": "^3.1",
+        "php-http/guzzle6-adapter": "^1.0",
+        "phpstan/phpstan": "^0.11",
+        "rector/rector": "^0.5.23",
         "phing/phing": "~2.16.0"
     },
     "autoload": {
         "psr-4": {
-            "OpenTok\\": "src/OpenTok"
+            "OpenTok\\": "src/OpenTok",
+            "OpenTokTest\\": "tests/OpenTokTest"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "issues": "https://github.com/opentok/Opentok-PHP-SDK/issues"
     },
     "require": {
-        "php": ">=5.6.0",
+        "php": "^7.1",
         "johnstevenson/json-works": "~1.1",
         "firebase/php-jwt": "^5.0",
         "guzzlehttp/guzzle": "~6.0"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset name="PSR2">
+    <rule ref="PSR2"/>
+    <file>./src</file>
+</ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PSR2">
-    <rule ref="PSR2"/>
+<ruleset name="PSR12">
+    <rule ref="PSR12"/>
     <file>./src</file>
 </ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: 6
+    paths:
+        - src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,13 +3,13 @@
 <phpunit bootstrap="tests/bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="OpenTok Test Suite">
-            <directory>tests/OpenTok/</directory>
+            <directory>tests/</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist>
-            <directory suffix=".php">src/OpenTok/</directory>
+            <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
 

--- a/rector.yaml
+++ b/rector.yaml
@@ -1,0 +1,5 @@
+parameters:
+    php_version_features: '7.1'
+    import_short_classes: false
+    sets:
+        - dead-code

--- a/sample/Archiving/.gitignore
+++ b/sample/Archiving/.gitignore
@@ -1,0 +1,2 @@
+.htaccess
+web/cache/

--- a/sample/Archiving/README.md
+++ b/sample/Archiving/README.md
@@ -5,9 +5,13 @@ Sessions, list archives that have been created, download the recordings, and del
 
 ## Running the App
 
-First, download the dependencies using [Composer](http://getcomposer.org) in this directory.
+First, download the dependencies using [Composer](http://getcomposer.org) in this directory as well
+as the root SDK directory
 
 ```
+$ cd ../../
+$ composer.phar install
+$ cd sample/Archiving
 $ ../../composer.phar install
 ```
 

--- a/sample/Archiving/composer.json
+++ b/sample/Archiving/composer.json
@@ -1,11 +1,9 @@
 {
   "name": "archiving-php",
-  "minimum-stability":"dev",
   "require": {
     "slim/slim": "2.*",
     "slim/views": "0.1.*",
     "twig/twig": "1.*",
-    "gregwar/cache": "1.0.*",
-    "opentok/opentok": "dev-master"
+    "gregwar/cache": "1.0.*"
   }
 }

--- a/sample/Archiving/web/index.php
+++ b/sample/Archiving/web/index.php
@@ -1,11 +1,18 @@
 <?php
 
-$autoloader = __DIR__.'/../vendor/autoload.php';
+$autoloader = __DIR__ . '/../vendor/autoload.php';
+$sdkAutoloader = __DIR__ . '/../../../vendor/autoload.php';
+
 if (!file_exists($autoloader)) {
-  die('You must run `composer install` in the sample app directory');
+    die('You must run `composer install` in the sample app directory');
+}
+
+if (!file_exists($sdkAutoloader)) {
+    die('You must run `composer install` in the SDK root directory');
 }
 
 require($autoloader);
+require($sdkAutoloader);
 
 use Slim\Slim;
 use Gregwar\Cache\Cache;
@@ -16,7 +23,7 @@ use OpenTok\MediaMode;
 use OpenTok\OutputMode;
 
 // PHP CLI webserver compatibility, serving static files
-$filename = __DIR__.preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
+$filename = __DIR__ . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
 if (php_sapi_name() === 'cli-server' && is_file($filename)) {
     return false;
 }
@@ -28,13 +35,13 @@ if (!(getenv('API_KEY') && getenv('API_SECRET'))) {
 
 // Initialize Slim application
 $app = new Slim(array(
-    'templates.path' => __DIR__.'/../templates',
-    'view' => new \Slim\Views\Twig()
+    'templates.path' => __DIR__ . '/../templates',
+    'view' => new \Slim\Views\Twig(),
 ));
 
 // Intialize a cache, store it in the app container
 $app->container->singleton('cache', function () {
-    return new Cache;
+    return new Cache();
 });
 
 // Initialize OpenTok instance, store it in the app contianer
@@ -95,13 +102,13 @@ $app->get('/history', function () use ($app) {
     $archives = $app->opentok->listArchives($offset, 5);
 
     $toArray = function ($archive) {
-      return $archive->toArray();
+        return $archive->toArray();
     };
 
     $app->render('history.html', array(
         'archives' => array_map($toArray, $archives->getItems()),
-        'showPrevious' => $page > 1 ? '/history?page='.($page-1) : null,
-        'showNext' => $archives->totalCount() > $offset + 5 ? '/history?page='.($page+1) : null
+        'showPrevious' => $page > 1 ? '/history?page=' . ($page - 1) : null,
+        'showNext' => $archives->totalCount() > $offset + 5 ? '/history?page=' . ($page + 1) : null
     ));
 });
 

--- a/sample/HelloWorld/.gitignore
+++ b/sample/HelloWorld/.gitignore
@@ -1,0 +1,2 @@
+.htaccess
+web/cache/

--- a/sample/HelloWorld/README.md
+++ b/sample/HelloWorld/README.md
@@ -6,9 +6,13 @@ connect and conduct a group chat.
 
 ## Running the App
 
-First, download the dependencies using [Composer](http://getcomposer.org) in this directory.
+First, download the dependencies using [Composer](http://getcomposer.org) in this directory as well
+as the root SDK directory
 
 ```
+$ cd ../../
+$ composer.phar install
+$ cd sample/HelloWorld
 $ ../../composer.phar install
 ```
 
@@ -37,12 +41,13 @@ be explore further at each of the websites linked above.
 
 ### Main Controller (web/index.php)
 
-The first thing done in this file is to require the autoloader which pulls in all the dependencies
+The first thing done in this file is to require the autoloaders which pulls in all the dependencies
 that were installed by Composer. We now have the Slim framework, the Cache library, and most
 importantly the OpenTok SDK available.
 
 ```php
 require($autoloader);
+require($sdkAutoloader);
 
 use Slim\Slim;
 use Gregwar\Cache\Cache;

--- a/sample/HelloWorld/composer.json
+++ b/sample/HelloWorld/composer.json
@@ -1,9 +1,7 @@
 {
   "name": "helloworld-php",
-  "minimum-stability":"dev",
   "require": {
     "slim/slim": "2.*",
-    "gregwar/cache": "1.0.*",
-    "opentok/opentok": "dev-master"
+    "gregwar/cache": "1.0.*"
   }
 }

--- a/sample/HelloWorld/web/index.php
+++ b/sample/HelloWorld/web/index.php
@@ -1,11 +1,18 @@
 <?php
 
-$autoloader = __DIR__.'/../vendor/autoload.php';
+$autoloader = __DIR__ . '/../vendor/autoload.php';
+$sdkAutoloader = __DIR__ . '/../../../vendor/autoload.php';
+
 if (!file_exists($autoloader)) {
-  die('You must run `composer install` in the sample app directory');
+    die('You must run `composer install` in the sample app directory');
+}
+
+if (!file_exists($sdkAutoloader)) {
+    die('You must run `composer install` in the SDK root directory');
 }
 
 require($autoloader);
+require($sdkAutoloader);
 
 use Slim\Slim;
 use Gregwar\Cache\Cache;
@@ -13,7 +20,7 @@ use Gregwar\Cache\Cache;
 use OpenTok\OpenTok;
 
 // PHP CLI webserver compatibility, serving static files
-$filename = __DIR__.preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
+$filename = __DIR__ . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
 if (php_sapi_name() === 'cli-server' && is_file($filename)) {
     return false;
 }
@@ -25,12 +32,12 @@ if (!(getenv('API_KEY') && getenv('API_SECRET'))) {
 
 // Initialize Slim application
 $app = new Slim(array(
-    'templates.path' => __DIR__.'/../templates'
+    'templates.path' => __DIR__ . '/../templates'
 ));
 
 // Intialize a cache, store it in the app container
 $app->container->singleton('cache', function () {
-    return new Cache;
+    return new Cache();
 });
 
 // Initialize OpenTok instance, store it in the app contianer

--- a/sample/SipCall/.gitignore
+++ b/sample/SipCall/.gitignore
@@ -1,0 +1,2 @@
+.htaccess
+web/cache/

--- a/sample/SipCall/README.md
+++ b/sample/SipCall/README.md
@@ -4,9 +4,13 @@ This is a simple demo app that shows how you can use the OpenTok-PHP-SDK to join
 
 ## Running the App
 
-First, download the dependencies using [Composer](http://getcomposer.org) in this directory.
+First, download the dependencies using [Composer](http://getcomposer.org) in this directory, as well
+as the root SDK directory
 
 ```
+$ cd ../../
+$ composer.phar install
+$ cd sample/SipCall
 $ ../../composer.phar install
 ```
 

--- a/sample/SipCall/composer.json
+++ b/sample/SipCall/composer.json
@@ -1,9 +1,7 @@
 {
   "name": "sipcall-php",
-  "minimum-stability":"dev",
   "require": {
     "slim/slim": "2.*",
-    "gregwar/cache": "1.0.*",
-    "opentok/opentok": "dev-master"
+    "gregwar/cache": "1.0.*"
   }
 }

--- a/sample/SipCall/web/index.php
+++ b/sample/SipCall/web/index.php
@@ -1,15 +1,18 @@
 <?php
 
-$autoloader = __DIR__.'/../vendor/autoload.php';
+$autoloader = __DIR__ . '/../vendor/autoload.php';
+$sdkAutoloader = __DIR__ . '/../../../vendor/autoload.php';
+
 if (!file_exists($autoloader)) {
-  die('You must run `composer install` in the sample app directory');
+    die('You must run `composer install` in the sample app directory');
+}
+
+if (!file_exists($sdkAutoloader)) {
+    die('You must run `composer install` in the SDK root directory');
 }
 
 require($autoloader);
-
-// remove this before push
-$autoloader2 = __DIR__.'/../../../vendor/autoload.php';
-require($autoloader2);
+require($sdkAutoloader);
 
 use Slim\Slim;
 use Gregwar\Cache\Cache;
@@ -18,7 +21,7 @@ use OpenTok\OpenTok;
 use OpenTok\MediaMode;
 
 // PHP CLI webserver compatibility, serving static files
-$filename = __DIR__.preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
+$filename = __DIR__ . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
 if (php_sapi_name() === 'cli-server' && is_file($filename)) {
     return false;
 }
@@ -30,12 +33,12 @@ if (!(getenv('API_KEY') && getenv('API_SECRET') && getenv('SIP_URI') && getenv('
 
 // Initialize Slim application
 $app = new Slim(array(
-    'templates.path' => __DIR__.'/../templates'
+    'templates.path' => __DIR__ . '/../templates'
 ));
 
 // Intialize a cache, store it in the app container
 $app->container->singleton('cache', function () {
-    return new Cache;
+    return new Cache();
 });
 
 // Initialize OpenTok instance, store it in the app contianer

--- a/src/OpenTok/Archive.php
+++ b/src/OpenTok/Archive.php
@@ -4,7 +4,6 @@ namespace OpenTok;
 
 use OpenTok\Util\Client;
 use OpenTok\Util\Validators;
-
 use OpenTok\Exception\InvalidArgumentException;
 use OpenTok\Exception\ArchiveUnexpectedValueException;
 
@@ -77,7 +76,8 @@ use OpenTok\Exception\ArchiveUnexpectedValueException;
 * set to null. The download URL is obfuscated, and the file is only available from the URL for
 * 10 minutes. To generate a new URL, call the Archive.listArchives() or OpenTok.getArchive() method.
 */
-class Archive {
+class Archive
+{
     // NOTE: after PHP 5.3.0 support is dropped, the class can implement JsonSerializable
 
     /** @internal */
@@ -122,7 +122,7 @@ class Archive {
         if ($this->isDeleted) {
             // TODO: throw an logic error about not being able to stop an archive thats deleted
         }
-        switch($name) {
+        switch ($name) {
             case 'createdAt':
             case 'duration':
             case 'id':

--- a/src/OpenTok/Archive.php
+++ b/src/OpenTok/Archive.php
@@ -138,7 +138,6 @@ class Archive
             case 'outputMode':
             case 'resolution':
                 return $this->data[$name];
-                break;
             default:
                 return null;
         }

--- a/src/OpenTok/Archive.php
+++ b/src/OpenTok/Archive.php
@@ -218,5 +218,3 @@ class Archive
         return $this->data;
     }
 }
-
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/ArchiveList.php
+++ b/src/OpenTok/ArchiveList.php
@@ -88,5 +88,3 @@ class ArchiveList
         return $this->items;
     }
 }
-
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/ArchiveList.php
+++ b/src/OpenTok/ArchiveList.php
@@ -20,14 +20,6 @@ class ArchiveList
     /**
     * @internal
     */
-    private $apiKey;
-    /**
-    * @internal
-    */
-    private $apiSecret;
-    /**
-    * @internal
-    */
     private $client;
     /**
     * @internal

--- a/src/OpenTok/ArchiveList.php
+++ b/src/OpenTok/ArchiveList.php
@@ -10,7 +10,8 @@ use OpenTok\Util\Validators;
 /**
 * A class for accessing an array of Archive objects.
 */
-class ArchiveList {
+class ArchiveList
+{
 
     /**
     * @internal
@@ -79,7 +80,7 @@ class ArchiveList {
     {
         if (!$this->items) {
             $items = array();
-            foreach($this->data['items'] as $archiveData) {
+            foreach ($this->data['items'] as $archiveData) {
                 $items[] = new Archive($archiveData, array( 'client' => $this->client ));
             }
             $this->items = $items;

--- a/src/OpenTok/ArchiveMode.php
+++ b/src/OpenTok/ArchiveMode.php
@@ -24,5 +24,3 @@ abstract class ArchiveMode extends BasicEnum
      */
     const ALWAYS = 'always';
 }
-
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/ArchiveMode.php
+++ b/src/OpenTok/ArchiveMode.php
@@ -11,7 +11,8 @@ use OpenTok\Util\BasicEnum;
  * See <a href="OpenTok.OpenTok.html#method_createSession">OpenTok->createSession()</a>
  * and <a href="OpenTok.Archive.html#method_getArchiveMode">Session->getArchiveMode()</a>.
  */
-abstract class ArchiveMode extends BasicEnum {
+abstract class ArchiveMode extends BasicEnum
+{
     /**
      * The session is not archived automatically. To archive the session, you can call the
      * \OpenTok\OpenTok->startArchive() method.

--- a/src/OpenTok/Broadcast.php
+++ b/src/OpenTok/Broadcast.php
@@ -12,7 +12,7 @@ use OpenTok\Util\Validators;
 * Represents a broadcast of an OpenTok session.
 *
 * @property int $createdAt
-* The timestamp when the broadcast was created, expressed in seconds since the Unix epoch. 
+* The timestamp when the broadcast was created, expressed in seconds since the Unix epoch.
 *
 * @property int $updatedAt
 * The time the broadcast was started or stopped, expressed in seconds since the Unix epoch.
@@ -35,7 +35,8 @@ use OpenTok\Util\Validators;
 * @property boolean $isStopped
 * Whether the broadcast is stopped (true) or in progress (false).
 */
-class Broadcast {
+class Broadcast
+{
     // NOTE: after PHP 5.3.0 support is dropped, the class can implement JsonSerializable
 
     /** @ignore */

--- a/src/OpenTok/Broadcast.php
+++ b/src/OpenTok/Broadcast.php
@@ -92,13 +92,10 @@ class Broadcast
             case 'maxDuration':
             case 'resolution':
                 return $this->data[$name];
-                break;
             case 'hlsUrl':
                 return $this->data['broadcastUrls']['hls'];
-                break;
             case 'isStopped':
                 return $this->isStopped;
-                break;
             default:
                 return null;
         }

--- a/src/OpenTok/Exception/ArchiveAuthenticationException.php
+++ b/src/OpenTok/Exception/ArchiveAuthenticationException.php
@@ -5,6 +5,6 @@ namespace OpenTok\Exception;
 /**
  * Defines the exception thrown when you use an invalid API or secret and call an archiving method.
  */
-class ArchiveAuthenticationException extends \OpenTok\Exception\AuthenticationException implements \OpenTok\Exception\ArchiveException
+class ArchiveAuthenticationException extends AuthenticationException implements ArchiveException
 {
 }

--- a/src/OpenTok/Exception/ArchiveAuthenticationException.php
+++ b/src/OpenTok/Exception/ArchiveAuthenticationException.php
@@ -8,4 +8,3 @@ namespace OpenTok\Exception;
 class ArchiveAuthenticationException extends \OpenTok\Exception\AuthenticationException implements \OpenTok\Exception\ArchiveException
 {
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/ArchiveDomainException.php
+++ b/src/OpenTok/Exception/ArchiveDomainException.php
@@ -7,6 +7,6 @@ namespace OpenTok\Exception;
 * Defines an exception thrown when a call to an archiving method results in an error response from
 * the server.
 */
-class ArchiveDomainException extends \OpenTok\Exception\DomainException implements \OpenTok\Exception\ArchiveException
+class ArchiveDomainException extends DomainException implements ArchiveException
 {
 }

--- a/src/OpenTok/Exception/ArchiveDomainException.php
+++ b/src/OpenTok/Exception/ArchiveDomainException.php
@@ -10,4 +10,3 @@ namespace OpenTok\Exception;
 class ArchiveDomainException extends \OpenTok\Exception\DomainException implements \OpenTok\Exception\ArchiveException
 {
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/ArchiveException.php
+++ b/src/OpenTok/Exception/ArchiveException.php
@@ -8,4 +8,3 @@ namespace OpenTok\Exception;
 interface ArchiveException
 {
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/ArchiveUnexpectedValueException.php
+++ b/src/OpenTok/Exception/ArchiveUnexpectedValueException.php
@@ -6,6 +6,6 @@ namespace OpenTok\Exception;
 * Defines an exception thrown when a call to an archiving method results in an error due to an
 * unexpected value.
 */
-class ArchiveUnexpectedValueException extends \OpenTok\Exception\UnexpectedValueException implements \OpenTok\Exception\ArchiveException
+class ArchiveUnexpectedValueException extends UnexpectedValueException implements ArchiveException
 {
 }

--- a/src/OpenTok/Exception/ArchiveUnexpectedValueException.php
+++ b/src/OpenTok/Exception/ArchiveUnexpectedValueException.php
@@ -9,4 +9,3 @@ namespace OpenTok\Exception;
 class ArchiveUnexpectedValueException extends \OpenTok\Exception\UnexpectedValueException implements \OpenTok\Exception\ArchiveException
 {
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/AuthenticationException.php
+++ b/src/OpenTok/Exception/AuthenticationException.php
@@ -6,7 +6,7 @@ namespace OpenTok\Exception;
 /**
  * Defines the exception thrown when you use an invalid API or secret.
  */
-class AuthenticationException extends \OpenTok\Exception\DomainException implements \OpenTok\Exception\Exception
+class AuthenticationException extends DomainException implements Exception
 {
   /** @ignore */
     public function __construct($apiKey, $apiSecret, $code = 0, $previous)

--- a/src/OpenTok/Exception/AuthenticationException.php
+++ b/src/OpenTok/Exception/AuthenticationException.php
@@ -11,8 +11,8 @@ class AuthenticationException extends \OpenTok\Exception\DomainException impleme
   /** @ignore */
     public function __construct($apiKey, $apiSecret, $code = 0, $previous)
     {
-        $message = 'The OpenTok API credentials were rejected. apiKey='.$apiKey.', apiSecret='.$apiSecret;
-         parent::__construct($message, $code, $previous);
+        $message = 'The OpenTok API credentials were rejected. apiKey=' . $apiKey . ', apiSecret=' . $apiSecret;
+        parent::__construct($message, $code, $previous);
     }
 }
 /* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/AuthenticationException.php
+++ b/src/OpenTok/Exception/AuthenticationException.php
@@ -15,4 +15,3 @@ class AuthenticationException extends \OpenTok\Exception\DomainException impleme
         parent::__construct($message, $code, $previous);
     }
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/BroadcastAuthenticationException.php
+++ b/src/OpenTok/Exception/BroadcastAuthenticationException.php
@@ -8,4 +8,3 @@ namespace OpenTok\Exception;
 class BroadcastAuthenticationException extends \OpenTok\Exception\AuthenticationException implements \OpenTok\Exception\BroadcastException
 {
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/BroadcastAuthenticationException.php
+++ b/src/OpenTok/Exception/BroadcastAuthenticationException.php
@@ -5,6 +5,6 @@ namespace OpenTok\Exception;
 /**
  * Defines the exception thrown when you use an invalid API or secret and call a broadcast method.
  */
-class BroadcastAuthenticationException extends \OpenTok\Exception\AuthenticationException implements \OpenTok\Exception\BroadcastException
+class BroadcastAuthenticationException extends AuthenticationException implements BroadcastException
 {
 }

--- a/src/OpenTok/Exception/BroadcastDomainException.php
+++ b/src/OpenTok/Exception/BroadcastDomainException.php
@@ -7,6 +7,6 @@ namespace OpenTok\Exception;
 * Defines an exception thrown when a call to a broadcast method results in an error response from
 * the server.
 */
-class BroadcastDomainException extends \OpenTok\Exception\DomainException implements \OpenTok\Exception\BroadcastException
+class BroadcastDomainException extends DomainException implements BroadcastException
 {
 }

--- a/src/OpenTok/Exception/BroadcastDomainException.php
+++ b/src/OpenTok/Exception/BroadcastDomainException.php
@@ -10,4 +10,3 @@ namespace OpenTok\Exception;
 class BroadcastDomainException extends \OpenTok\Exception\DomainException implements \OpenTok\Exception\BroadcastException
 {
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/BroadcastException.php
+++ b/src/OpenTok/Exception/BroadcastException.php
@@ -8,4 +8,3 @@ namespace OpenTok\Exception;
 interface BroadcastException
 {
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/BroadcastUnexpectedValueException.php
+++ b/src/OpenTok/Exception/BroadcastUnexpectedValueException.php
@@ -9,4 +9,3 @@ namespace OpenTok\Exception;
 class BroadcastUnexpectedValueException extends \OpenTok\Exception\UnexpectedValueException implements \OpenTok\Exception\BroadcastException
 {
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/BroadcastUnexpectedValueException.php
+++ b/src/OpenTok/Exception/BroadcastUnexpectedValueException.php
@@ -6,6 +6,6 @@ namespace OpenTok\Exception;
 * Defines an exception thrown when a call to a broadcast method results in an error due to an
 * unexpected value.
 */
-class BroadcastUnexpectedValueException extends \OpenTok\Exception\UnexpectedValueException implements \OpenTok\Exception\BroadcastException
+class BroadcastUnexpectedValueException extends UnexpectedValueException implements BroadcastException
 {
 }

--- a/src/OpenTok/Exception/DomainException.php
+++ b/src/OpenTok/Exception/DomainException.php
@@ -6,6 +6,6 @@ namespace OpenTok\Exception;
 * Defines an exception thrown when an API call results in an error response from
 * the server.
 */
-class DomainException extends \DomainException implements \OpenTok\Exception\Exception
+class DomainException extends \DomainException implements Exception
 {
 }

--- a/src/OpenTok/Exception/DomainException.php
+++ b/src/OpenTok/Exception/DomainException.php
@@ -9,4 +9,3 @@ namespace OpenTok\Exception;
 class DomainException extends \DomainException implements \OpenTok\Exception\Exception
 {
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/Exception.php
+++ b/src/OpenTok/Exception/Exception.php
@@ -5,7 +5,7 @@ namespace OpenTok\Exception;
 /**
 * The interface used by all exceptions in the OpenTok PHP API.
 */
-interface Exception 
+interface Exception
 {
 }
 /* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/Exception.php
+++ b/src/OpenTok/Exception/Exception.php
@@ -8,4 +8,3 @@ namespace OpenTok\Exception;
 interface Exception
 {
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/ForceDisconnectAuthenticationException.php
+++ b/src/OpenTok/Exception/ForceDisconnectAuthenticationException.php
@@ -5,6 +5,6 @@ namespace OpenTok\Exception;
 /**
  * Defines the exception thrown when you use an invalid API or secret and call the force disconnect method.
  */
-class ForceDisconnectAuthenticationException extends \OpenTok\Exception\AuthenticationException implements \OpenTok\Exception\ForceDisconnectException
+class ForceDisconnectAuthenticationException extends AuthenticationException implements ForceDisconnectException
 {
 }

--- a/src/OpenTok/Exception/ForceDisconnectConnectionException.php
+++ b/src/OpenTok/Exception/ForceDisconnectConnectionException.php
@@ -8,10 +8,9 @@ namespace OpenTok\Exception;
 */
 class ForceDisconnectConnectionException extends \OpenTok\Exception\DomainException implements \OpenTok\Exception\ForceDisconnectException
 {
-  /** @ignore */
-
-  public function __construct($message, $code)
-  {
-      parent::__construct($message, $code);
-  }
+    /** @ignore */
+    public function __construct($message, $code)
+    {
+        parent::__construct($message, $code);
+    }
 }

--- a/src/OpenTok/Exception/ForceDisconnectConnectionException.php
+++ b/src/OpenTok/Exception/ForceDisconnectConnectionException.php
@@ -6,7 +6,7 @@ namespace OpenTok\Exception;
 * Defines an exception thrown when a call to a force disconnect method results in an error response from
 * the server.
 */
-class ForceDisconnectConnectionException extends \OpenTok\Exception\DomainException implements \OpenTok\Exception\ForceDisconnectException
+class ForceDisconnectConnectionException extends DomainException implements ForceDisconnectException
 {
     /** @ignore */
     public function __construct($message, $code)

--- a/src/OpenTok/Exception/ForceDisconnectUnexpectedValueException.php
+++ b/src/OpenTok/Exception/ForceDisconnectUnexpectedValueException.php
@@ -8,10 +8,9 @@ namespace OpenTok\Exception;
 */
 class ForceDisconnectUnexpectedValueException extends \OpenTok\Exception\UnexpectedValueException implements \OpenTok\Exception\ForceDisconnectException
 {
-  /** @ignore */
-
-  public function __construct($message, $code)
-  {
-      parent::__construct($message, $code);
-  }
+    /** @ignore */
+    public function __construct($message, $code)
+    {
+        parent::__construct($message, $code);
+    }
 }

--- a/src/OpenTok/Exception/ForceDisconnectUnexpectedValueException.php
+++ b/src/OpenTok/Exception/ForceDisconnectUnexpectedValueException.php
@@ -6,7 +6,7 @@ namespace OpenTok\Exception;
 * Defines an exception thrown when a call to the force disconnect method results in an error due to an
 * unexpected value.
 */
-class ForceDisconnectUnexpectedValueException extends \OpenTok\Exception\UnexpectedValueException implements \OpenTok\Exception\ForceDisconnectException
+class ForceDisconnectUnexpectedValueException extends UnexpectedValueException implements ForceDisconnectException
 {
     /** @ignore */
     public function __construct($message, $code)

--- a/src/OpenTok/Exception/InvalidArgumentException.php
+++ b/src/OpenTok/Exception/InvalidArgumentException.php
@@ -8,4 +8,3 @@ namespace OpenTok\Exception;
 class InvalidArgumentException extends \InvalidArgumentException implements \OpenTok\Exception\Exception
 {
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Exception/InvalidArgumentException.php
+++ b/src/OpenTok/Exception/InvalidArgumentException.php
@@ -5,6 +5,6 @@ namespace OpenTok\Exception;
 /**
 * Defines an exception thrown when you pass an invalid argument into a method.
 */
-class InvalidArgumentException extends \InvalidArgumentException implements \OpenTok\Exception\Exception
+class InvalidArgumentException extends \InvalidArgumentException implements Exception
 {
 }

--- a/src/OpenTok/Exception/SignalAuthenticationException.php
+++ b/src/OpenTok/Exception/SignalAuthenticationException.php
@@ -5,6 +5,6 @@ namespace OpenTok\Exception;
 /**
  * Defines the exception thrown when you use an invalid API or secret and call a signal method.
  */
-class SignalAuthenticationException extends \OpenTok\Exception\AuthenticationException implements \OpenTok\Exception\SignalException
+class SignalAuthenticationException extends AuthenticationException implements SignalException
 {
 }

--- a/src/OpenTok/Exception/SignalConnectionException.php
+++ b/src/OpenTok/Exception/SignalConnectionException.php
@@ -8,10 +8,9 @@ namespace OpenTok\Exception;
 */
 class SignalConnectionException extends \OpenTok\Exception\DomainException implements \OpenTok\Exception\SignalException
 {
-  /** @ignore */
-
-  public function __construct($message, $code)
-  {
-      parent::__construct($message, $code);
-  }
+    /** @ignore */
+    public function __construct($message, $code)
+    {
+        parent::__construct($message, $code);
+    }
 }

--- a/src/OpenTok/Exception/SignalConnectionException.php
+++ b/src/OpenTok/Exception/SignalConnectionException.php
@@ -6,7 +6,7 @@ namespace OpenTok\Exception;
 * Defines an exception thrown when a call to a signal method results in an error response from
 * the server.
 */
-class SignalConnectionException extends \OpenTok\Exception\DomainException implements \OpenTok\Exception\SignalException
+class SignalConnectionException extends DomainException implements SignalException
 {
     /** @ignore */
     public function __construct($message, $code)

--- a/src/OpenTok/Exception/SignalUnexpectedValueException.php
+++ b/src/OpenTok/Exception/SignalUnexpectedValueException.php
@@ -6,7 +6,7 @@ namespace OpenTok\Exception;
 * Defines an exception thrown when a call to a signal method results in an error due to an
 * unexpected value.
 */
-class SignalUnexpectedValueException extends \OpenTok\Exception\UnexpectedValueException implements \OpenTok\Exception\SignalException
+class SignalUnexpectedValueException extends UnexpectedValueException implements SignalException
 {
     /** @ignore */
     public function __construct($message, $code)

--- a/src/OpenTok/Exception/SignalUnexpectedValueException.php
+++ b/src/OpenTok/Exception/SignalUnexpectedValueException.php
@@ -8,10 +8,9 @@ namespace OpenTok\Exception;
 */
 class SignalUnexpectedValueException extends \OpenTok\Exception\UnexpectedValueException implements \OpenTok\Exception\SignalException
 {
-  /** @ignore */
-
-  public function __construct($message, $code)
-  {
-      parent::__construct($message, $code);
-  }
+    /** @ignore */
+    public function __construct($message, $code)
+    {
+        parent::__construct($message, $code);
+    }
 }

--- a/src/OpenTok/Exception/UnexpectedValueException.php
+++ b/src/OpenTok/Exception/UnexpectedValueException.php
@@ -5,6 +5,6 @@ namespace OpenTok\Exception;
 /**
 * Defines an exception thrown in result of an unexpected value.
 */
-class UnexpectedValueException extends \UnexpectedValueException implements \OpenTok\Exception\Exception
+class UnexpectedValueException extends \UnexpectedValueException implements Exception
 {
 }

--- a/src/OpenTok/Exception/UnexpectedValueException.php
+++ b/src/OpenTok/Exception/UnexpectedValueException.php
@@ -8,4 +8,3 @@ namespace OpenTok\Exception;
 class UnexpectedValueException extends \UnexpectedValueException implements \OpenTok\Exception\Exception
 {
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Layout.php
+++ b/src/OpenTok/Layout.php
@@ -24,13 +24,13 @@ class Layout
     // NOTE: after PHP 5.3.0 support is dropped, the class can implement JsonSerializable
 
     /** @ignore */
-    private static $bestFit = null;
+    private static $bestFit;
     /** @ignore */
-    private static $pip = null;
+    private static $pip;
     /** @ignore */
-    private static $verticalPresentation = null;
+    private static $verticalPresentation;
     /** @ignore */
-    private static $horizontalPresentation = null;
+    private static $horizontalPresentation;
 
     /**
      * Returns a Layout object defining the "best fit" predefined layout type.

--- a/src/OpenTok/Layout.php
+++ b/src/OpenTok/Layout.php
@@ -19,7 +19,8 @@ use OpenTok\Util\Validators;
  * <a href="https://tokbox.com/developer/guides/broadcast/live-streaming/#configuring-video-layout-for-opentok-live-streaming-broadcasts">Configuring
  * video layout for OpenTok live streaming broadcasts</a>.
  */
-class Layout {
+class Layout
+{
     // NOTE: after PHP 5.3.0 support is dropped, the class can implement JsonSerializable
 
     /** @ignore */
@@ -81,7 +82,7 @@ class Layout {
      * @param array $options An array containing one property: <code>$stylesheet<code>,
      * which is a string containing the stylesheet to be used for the layout.
      */
-   public static function createCustom($options)
+    public static function createCustom($options)
     {
         // unpack optional arguments (merging with default values) into named variables
         // NOTE: the default value of stylesheet=null will not pass validation, this essentially

--- a/src/OpenTok/MediaMode.php
+++ b/src/OpenTok/MediaMode.php
@@ -8,7 +8,8 @@ use OpenTok\Util\BasicEnum;
  * Defines values for the mediaMode parameter of the \OpenTok\OpenTok->createSession()
  * method.
  */
-abstract class MediaMode extends BasicEnum {
+abstract class MediaMode extends BasicEnum
+{
     /**
     *   The session will send streams using the OpenTok Media Router.
     */

--- a/src/OpenTok/MediaMode.php
+++ b/src/OpenTok/MediaMode.php
@@ -20,5 +20,3 @@ abstract class MediaMode extends BasicEnum
     */
     const RELAYED = 'enabled';
 }
-
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -251,7 +251,7 @@ class OpenTok
         // check response
         $sessionId = $sessionXml->Session->session_id;
         if (!$sessionId) {
-            $errorMessage = 'Failed to create a session. Server response: ' . (string)$sessionXml;
+            $errorMessage = 'Failed to create a session. Server response: ' . $sessionXml;
             throw new UnexpectedValueException($errorMessage);
         }
 
@@ -772,7 +772,7 @@ class OpenTok
         // check response
         $id = $sipJson['id'];
         if (!$id) {
-            $errorMessage = 'Failed to initiate a SIP call. Server response: ' . (string)$sipJson;
+            $errorMessage = 'Failed to initiate a SIP call. Server response: ' . $sipJson;
             throw new UnexpectedValueException($errorMessage);
         }
 

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -830,5 +830,3 @@ class OpenTok
         return hash_hmac("sha1", $string, $secret);
     }
 }
-
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -2,16 +2,6 @@
 
 namespace OpenTok;
 
-use OpenTok\Session;
-use OpenTok\Stream;
-use OpenTok\StreamList;
-use OpenTok\Archive;
-use OpenTok\Broadcast;
-use OpenTok\Layout;
-use OpenTok\Role;
-use OpenTok\MediaMode;
-use OpenTok\ArchiveMode;
-use OpenTok\OutputMode;
 use OpenTok\Util\Client;
 use OpenTok\Util\Validators;
 use OpenTok\Exception\UnexpectedValueException;
@@ -137,7 +127,7 @@ class OpenTok
             (($expireTime) ? "&expire_time=$expireTime" : '') .
             (($data) ? "&connection_data=" . urlencode($data) : '') .
             ((!empty($initialLayoutClassList)) ? "&initial_layout_class_list=" . urlencode(join(" ", $initialLayoutClassList)) : '');
-        $sig = $this->_sign_string($dataString, $this->apiSecret);
+        $sig = $this->signString($dataString, $this->apiSecret);
 
         return "T1==" . base64_encode("partner_id=$this->apiKey&sig=$sig:$dataString");
     }
@@ -825,7 +815,7 @@ class OpenTok
     }
 
     /** @internal */
-    private function _sign_string($string, $secret)
+    private function signString($string, $secret)
     {
         return hash_hmac("sha1", $string, $secret);
     }

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -14,7 +14,6 @@ use OpenTok\ArchiveMode;
 use OpenTok\OutputMode;
 use OpenTok\Util\Client;
 use OpenTok\Util\Validators;
-
 use OpenTok\Exception\UnexpectedValueException;
 use OpenTok\Exception\InvalidArgumentException;
 
@@ -28,7 +27,8 @@ use OpenTok\Exception\InvalidArgumentException;
 * <p>
 * Be sure to include the entire OpenTok server SDK on your web server.
 */
-class OpenTok {
+class OpenTok
+{
 
     /** @internal */
     private $apiKey;
@@ -96,7 +96,7 @@ class OpenTok {
      *    describing the end-user. For example, you can pass the user ID, name, or other data
      *    describing the end-user. The length of the string is limited to 1000 characters.
      *    This data cannot be updated once it is set.</li>
-     *    
+     *
      *    <li><code>initialLayoutClassList</code> (array) &mdash; An array of class names (strings)
      *      to be used as the initial layout classes for streams published by the client. Layout
      *      classes are used in customizing the layout of videos in
@@ -136,7 +136,7 @@ class OpenTok {
         $dataString = "session_id=$sessionId&create_time=$createTime&role=$role&nonce=$nonce" .
             (($expireTime) ? "&expire_time=$expireTime" : '') .
             (($data) ? "&connection_data=" . urlencode($data) : '') .
-            ((!empty($initialLayoutClassList)) ? "&initial_layout_class_list=" . urlencode(join(" ",$initialLayoutClassList)) : '');
+            ((!empty($initialLayoutClassList)) ? "&initial_layout_class_list=" . urlencode(join(" ", $initialLayoutClassList)) : '');
         $sig = $this->_sign_string($dataString, $this->apiSecret);
 
         return "T1==" . base64_encode("partner_id=$this->apiKey&sig=$sig:$dataString");
@@ -215,17 +215,19 @@ class OpenTok {
     * when using the OpenTok.js library, use this session ID when calling the
     * <code>OT.initSession()</code> method.
     */
-    public function createSession($options=array())
+    public function createSession($options = array())
     {
-        if (array_key_exists('archiveMode', $options) &&
-            $options['archiveMode'] != ArchiveMode::MANUAL) {
-
-            if (array_key_exists('mediaMode', $options) &&
-                $options['mediaMode'] != MediaMode::ROUTED) {
-
+        if (
+            array_key_exists('archiveMode', $options) &&
+            $options['archiveMode'] != ArchiveMode::MANUAL
+        ) {
+            if (
+                array_key_exists('mediaMode', $options) &&
+                $options['mediaMode'] != MediaMode::ROUTED
+            ) {
                 throw new InvalidArgumentException('A session must be routed to be archived.');
             } else {
-              $options['mediaMode'] = MediaMode::ROUTED;
+                $options['mediaMode'] = MediaMode::ROUTED;
             }
         }
 
@@ -249,7 +251,7 @@ class OpenTok {
         // check response
         $sessionId = $sessionXml->Session->session_id;
         if (!$sessionId) {
-            $errorMessage = 'Failed to create a session. Server response: '. (string)$sessionXml;
+            $errorMessage = 'Failed to create a session. Server response: ' . (string)$sessionXml;
             throw new UnexpectedValueException($errorMessage);
         }
 
@@ -304,7 +306,7 @@ class OpenTok {
      * @return Archive The Archive object, which includes properties defining the archive, including
      * the archive ID.
      */
-    public function startArchive($sessionId, $options=array())
+    public function startArchive($sessionId, $options = array())
     {
         // support for deprecated method signature, remove in v3.0.0 (not before)
         if (!is_array($options)) {
@@ -330,12 +332,12 @@ class OpenTok {
 
         if ((is_null($resolution) || empty($resolution)) && $outputMode === OutputMode::COMPOSED) {
             $options['resolution'] = "640x480";
-        } else if((is_null($resolution) || empty($resolution)) && $outputMode === OutputMode::INDIVIDUAL) {
+        } elseif ((is_null($resolution) || empty($resolution)) && $outputMode === OutputMode::INDIVIDUAL) {
             unset($options['resolution']);
-        } else if(!empty($resolution) && $outputMode === OutputMode::INDIVIDUAL) {
+        } elseif (!empty($resolution) && $outputMode === OutputMode::INDIVIDUAL) {
             $errorMessage = "Resolution can't be specified for Individual Archives";
             throw new UnexpectedValueException($errorMessage);
-        } else if(!empty($resolution) && $outputMode === OutputMode::COMPOSED && !is_string($resolution)) {
+        } elseif (!empty($resolution) && $outputMode === OutputMode::COMPOSED && !is_string($resolution)) {
             $errorMessage = "Resolution must be a valid string";
             throw new UnexpectedValueException($errorMessage);
         }
@@ -414,11 +416,11 @@ class OpenTok {
      * archives returned is 1000.
      * @param string $sessionId Optional. The OpenTok session Id for which you want to retrieve Archives for. If no session Id
      * is specified, the method will return archives from all sessions created with the API key.
-     * 
+     *
      * @return ArchiveList An ArchiveList object. Call the items() method of the ArchiveList object
      * to return an array of Archive objects.
      */
-    public function listArchives($offset=0, $count=null, $sessionId=null)
+    public function listArchives($offset = 0, $count = null, $sessionId = null)
     {
         // validate params
         Validators::validateOffsetAndCount($offset, $count);
@@ -459,12 +461,12 @@ class OpenTok {
      * @param array $classListArray The connectionId of the connection in a session.
      */
 
-    public function setStreamClassLists($sessionId, $classListArray=array())
+    public function setStreamClassLists($sessionId, $classListArray = array())
     {
         Validators::validateSessionIdBelongsToKey($sessionId, $this->apiKey);
         
-        foreach ($classListArray as $item ){
-            Validators::validateLayoutClassListItem($item);            
+        foreach ($classListArray as $item) {
+            Validators::validateLayoutClassListItem($item);
         }
         
         $this->client->setStreamClassLists($sessionId, $classListArray);
@@ -505,7 +507,7 @@ class OpenTok {
      *
      * @return Broadcast An object with properties defining the broadcast.
      */
-    public function startBroadcast($sessionId, $options=array())
+    public function startBroadcast($sessionId, $options = array())
     {
         // unpack optional arguments (merging with default values) into named variables
         // NOTE: although the server can be authoritative about the default value of layout, its
@@ -642,9 +644,9 @@ class OpenTok {
 
     /**
      * Gets an Stream object, providing information on a given stream.
-     * 
+     *
      * @param String $sessionId The session ID for the OpenTok session containing the stream.
-     * 
+     *
      * @param String $streamId The stream ID.
      *
      * @return Stream The Stream object.
@@ -658,16 +660,15 @@ class OpenTok {
         // make API call
         $streamData = $this->client->getStream($sessionId, $streamId);
         return new Stream($streamData);
-        
     }
 
     /**
      * Returns a StreamList Object for the given session ID.
-     * 
+     *
      * @param String $sessionId The session ID.
      *
      * @return StreamList A StreamList object. Call the items() method of the StreamList object
-     * to return an array of Stream objects.     
+     * to return an array of Stream objects.
      */
 
     public function listStreams($sessionId)
@@ -677,7 +678,6 @@ class OpenTok {
         // make API call
         $streamListData = $this->client->listStreams($sessionId);
         return new StreamList($streamListData);
-    
     }
 
     /**
@@ -751,7 +751,7 @@ class OpenTok {
      * to terminate the SIP call, using the
      * <a href="#method_forceDisconnect">OpenTok->forceDisconnect()</a> method.
      */
-    public function dial($sessionId, $token, $sipUri, $options=array())
+    public function dial($sessionId, $token, $sipUri, $options = array())
     {
         // unpack optional arguments (merging with default values) into named variables
         $defaults = array(
@@ -772,7 +772,7 @@ class OpenTok {
         // check response
         $id = $sipJson['id'];
         if (!$id) {
-            $errorMessage = 'Failed to initiate a SIP call. Server response: '. (string)$sipJson;
+            $errorMessage = 'Failed to initiate a SIP call. Server response: ' . (string)$sipJson;
             throw new UnexpectedValueException($errorMessage);
         }
 
@@ -795,10 +795,10 @@ class OpenTok {
      *
      * </ul>
      *
-     * 
+     *
      * @param string $connectionId An optional parameter used to send the signal to a specific connection in a session.
      */
-    public function signal($sessionId, $payload, $connectionId=null)
+    public function signal($sessionId, $payload, $connectionId = null)
     {
 
         // unpack optional arguments (merging with default values) into named variables
@@ -818,11 +818,10 @@ class OpenTok {
             // make API call without connectionId
             $this->client->signal($sessionId, $payload);
         } else {
-            Validators::validateConnectionId($connectionId); 
+            Validators::validateConnectionId($connectionId);
             // make API call with connectionId
             $this->client->signal($sessionId, $payload, $connectionId);
         }
-
     }
 
     /** @internal */

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -741,12 +741,12 @@ class OpenTok
      * to terminate the SIP call, using the
      * <a href="#method_forceDisconnect">OpenTok->forceDisconnect()</a> method.
      */
-    public function dial($sessionId, $token, $sipUri, $options = array())
+    public function dial($sessionId, $token, $sipUri, $options = [])
     {
         // unpack optional arguments (merging with default values) into named variables
         $defaults = array(
             'auth' => null,
-            'headers' => null,
+            'headers' => [],
             'secure' => true,
             'from' => null,
         );

--- a/src/OpenTok/OutputMode.php
+++ b/src/OpenTok/OutputMode.php
@@ -22,5 +22,3 @@ abstract class OutputMode extends BasicEnum
      */
     const INDIVIDUAL = 'individual';
 }
-
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/OutputMode.php
+++ b/src/OpenTok/OutputMode.php
@@ -11,7 +11,8 @@ use OpenTok\Util\BasicEnum;
  * See <a href="OpenTok.OpenTok.html#method_startArchive">OpenTok->startArchive()</a>
  * and <a href="OpenTok.Archive.html#property_outputMode">Archive.outputMode</a>.
  */
-abstract class OutputMode extends BasicEnum {
+abstract class OutputMode extends BasicEnum
+{
     /**
      * All streams in the archive are recorded to a single (composed) file.
      */

--- a/src/OpenTok/Role.php
+++ b/src/OpenTok/Role.php
@@ -8,7 +8,8 @@ use OpenTok\Util\BasicEnum;
  * Defines values for the role parameter of the \OpenTok\OpenTok->generateToken()
  * method.
  */
-abstract class Role extends BasicEnum {
+abstract class Role extends BasicEnum
+{
     /**
     *   A subscriber can only subscribe to streams.
     */

--- a/src/OpenTok/Role.php
+++ b/src/OpenTok/Role.php
@@ -26,5 +26,3 @@ abstract class Role extends BasicEnum
     */
     const MODERATOR = 'moderator';
 }
-
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Session.php
+++ b/src/OpenTok/Session.php
@@ -2,9 +2,6 @@
 
 namespace OpenTok;
 
-use OpenTok\OpenTok;
-use OpenTok\MediaMode;
-use OpenTok\ArchiveMode;
 use OpenTok\Util\Validators;
 
 /**
@@ -39,7 +36,7 @@ class Session
     /**
      * @internal
      */
-    function __construct($opentok, $sessionId, $properties = array())
+    public function __construct($opentok, $sessionId, $properties = array())
     {
         // unpack arguments
         $defaults = array('mediaMode' => MediaMode::ROUTED, 'archiveMode' => ArchiveMode::MANUAL, 'location' => null);

--- a/src/OpenTok/Session.php
+++ b/src/OpenTok/Session.php
@@ -57,7 +57,6 @@ class Session
         $this->location = $location;
         $this->mediaMode = $mediaMode;
         $this->archiveMode = $archiveMode;
-
     }
 
     /**

--- a/src/OpenTok/Session.php
+++ b/src/OpenTok/Session.php
@@ -144,5 +144,3 @@ class Session
         return $this->opentok->generateToken($this->sessionId, $options);
     }
 }
-
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/SipCall.php
+++ b/src/OpenTok/SipCall.php
@@ -2,11 +2,6 @@
 
 namespace OpenTok;
 
-use OpenTok\Util\Client;
-use OpenTok\Util\Validators;
-use OpenTok\Exception\InvalidArgumentException;
-use OpenTok\Exception\ArchiveUnexpectedValueException;
-
 /**
 * Represents data from a SIP Call
 *

--- a/src/OpenTok/SipCall.php
+++ b/src/OpenTok/SipCall.php
@@ -4,7 +4,6 @@ namespace OpenTok;
 
 use OpenTok\Util\Client;
 use OpenTok\Util\Validators;
-
 use OpenTok\Exception\InvalidArgumentException;
 use OpenTok\Exception\ArchiveUnexpectedValueException;
 
@@ -23,7 +22,8 @@ use OpenTok\Exception\ArchiveUnexpectedValueException;
 * The ID of the stream connected to the OpenTok session streaming the audio received from
 * the SIP call.
 */
-class SipCall {
+class SipCall
+{
 
     /** @internal */
     private $data;
@@ -42,7 +42,7 @@ class SipCall {
     /** @internal */
     public function __get($name)
     {
-        switch($name) {
+        switch ($name) {
             case 'id':
             case 'connectionId':
             case 'streamId':

--- a/src/OpenTok/SipCall.php
+++ b/src/OpenTok/SipCall.php
@@ -47,7 +47,6 @@ class SipCall
             case 'connectionId':
             case 'streamId':
                 return $this->data[$name];
-                break;
             default:
                 return null;
         }

--- a/src/OpenTok/SipCall.php
+++ b/src/OpenTok/SipCall.php
@@ -62,5 +62,3 @@ class SipCall
         return json_encode($this->data);
     }
 }
-
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Stream.php
+++ b/src/OpenTok/Stream.php
@@ -21,7 +21,8 @@ namespace OpenTok;
 * The type of video in the stream, which is set to either "camera" or "screen".
 */
 
-class Stream {
+class Stream
+{
 
     private $data;
 

--- a/src/OpenTok/Stream.php
+++ b/src/OpenTok/Stream.php
@@ -41,7 +41,6 @@ class Stream
             case 'name':
             case 'layoutClassList':
                 return $this->data[$name];
-                break;
             default:
                 return null;
         }

--- a/src/OpenTok/Util/BasicEnum.php
+++ b/src/OpenTok/Util/BasicEnum.php
@@ -7,7 +7,7 @@ namespace OpenTok\Util;
 */
 abstract class BasicEnum
 {
-    private static $constCacheArray = null;
+    private static $constCacheArray;
 
     private static function getConstants()
     {

--- a/src/OpenTok/Util/BasicEnum.php
+++ b/src/OpenTok/Util/BasicEnum.php
@@ -5,12 +5,15 @@ namespace OpenTok\Util;
 /**
 * @internal
 */
-abstract class BasicEnum {
+abstract class BasicEnum
+{
     private static $constCacheArray = null;
 
     private static function getConstants()
     {
-        if (self::$constCacheArray === null) self::$constCacheArray = array();
+        if (self::$constCacheArray === null) {
+            self::$constCacheArray = array();
+        }
 
         $calledClass = get_called_class();
         if (!array_key_exists($calledClass, self::$constCacheArray)) {

--- a/src/OpenTok/Util/BasicEnum.php
+++ b/src/OpenTok/Util/BasicEnum.php
@@ -42,4 +42,3 @@ abstract class BasicEnum
         return in_array($value, $values, $strict = true);
     }
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/src/OpenTok/Util/Client.php
+++ b/src/OpenTok/Util/Client.php
@@ -478,7 +478,7 @@ class Client
             )
         );
 
-        if (isset($options) && array_key_exists('headers', $options) && sizeof($options['headers']) > 0) {
+        if (isset($options) && array_key_exists('headers', $options) && count($options['headers']) > 0) {
             $body['sip']['headers'] = $options['headers'];
         }
 

--- a/src/OpenTok/Util/Client.php
+++ b/src/OpenTok/Util/Client.php
@@ -2,7 +2,6 @@
 
 namespace OpenTok\Util;
 
-use function GuzzleHttp\default_user_agent;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Exception\ClientException;
@@ -22,7 +21,6 @@ use OpenTok\Exception\BroadcastException;
 use OpenTok\Exception\BroadcastDomainException;
 use OpenTok\Exception\BroadcastUnexpectedValueException;
 use OpenTok\Exception\BroadcastAuthenticationException;
-use OpenTok\Exception\SignalException;
 use OpenTok\Exception\SignalConnectionException;
 use OpenTok\Exception\SignalUnexpectedValueException;
 use OpenTok\Exception\SignalAuthenticationException;
@@ -30,6 +28,8 @@ use OpenTok\Exception\ForceDisconnectConnectionException;
 use OpenTok\Exception\ForceDisconnectUnexpectedValueException;
 use OpenTok\Exception\ForceDisconnectAuthenticationException;
 use OpenTok\MediaMode;
+
+use function GuzzleHttp\default_user_agent;
 
 // TODO: build this dynamically
 /** @internal */

--- a/src/OpenTok/Util/Client.php
+++ b/src/OpenTok/Util/Client.php
@@ -9,31 +9,25 @@ use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\RequestInterface;
 use Firebase\JWT\JWT;
-
 use OpenTok\Exception\Exception;
 use OpenTok\Exception\DomainException;
 use OpenTok\Exception\UnexpectedValueException;
 use OpenTok\Exception\AuthenticationException;
-
 use OpenTok\Exception\ArchiveException;
 use OpenTok\Exception\ArchiveDomainException;
 use OpenTok\Exception\ArchiveUnexpectedValueException;
 use OpenTok\Exception\ArchiveAuthenticationException;
-
 use OpenTok\Exception\BroadcastException;
 use OpenTok\Exception\BroadcastDomainException;
 use OpenTok\Exception\BroadcastUnexpectedValueException;
 use OpenTok\Exception\BroadcastAuthenticationException;
-
 use OpenTok\Exception\SignalException;
 use OpenTok\Exception\SignalConnectionException;
 use OpenTok\Exception\SignalUnexpectedValueException;
 use OpenTok\Exception\SignalAuthenticationException;
-
 use OpenTok\Exception\ForceDisconnectConnectionException;
 use OpenTok\Exception\ForceDisconnectUnexpectedValueException;
 use OpenTok\Exception\ForceDisconnectAuthenticationException;
-
 use OpenTok\MediaMode;
 
 // TODO: build this dynamically
@@ -96,7 +90,7 @@ class Client
             'ist' => 'project',
             'iss' => $this->apiKey,
             'iat' => time(), // this is in seconds
-            'exp' => time()+(5 * 60),
+            'exp' => time() + (5 * 60),
             'jti' => uniqid(),
         );
         return JWT::encode($token, $this->apiSecret);
@@ -153,7 +147,7 @@ class Client
     public function startArchive($sessionId, $options)
     {
         // set up the request
-        $request = new Request('POST', '/v2/project/'.$this->apiKey.'/archive');
+        $request = new Request('POST', '/v2/project/' . $this->apiKey . '/archive');
 
         try {
             $response = $this->client->send($request, [
@@ -175,7 +169,7 @@ class Client
         // set up the request
         $request = new Request(
             'POST',
-            '/v2/project/'.$this->apiKey.'/archive/'.$archiveId.'/stop',
+            '/v2/project/' . $this->apiKey . '/archive/' . $archiveId . '/stop',
             ['Content-Type' => 'application/json']
         );
 
@@ -195,7 +189,7 @@ class Client
     {
         $request = new Request(
             'GET',
-            '/v2/project/'.$this->apiKey.'/archive/'.$archiveId
+            '/v2/project/' . $this->apiKey . '/archive/' . $archiveId
         );
         try {
             $response = $this->client->send($request, [
@@ -213,7 +207,7 @@ class Client
     {
         $request = new Request(
             'DELETE',
-            '/v2/project/'.$this->apiKey.'/archive/'.$archiveId,
+            '/v2/project/' . $this->apiKey . '/archive/' . $archiveId,
             ['Content-Type' => 'application/json']
         );
         try {
@@ -230,11 +224,11 @@ class Client
         return true;
     }
 
-    public function forceDisconnect($sessionId,$connectionId)
+    public function forceDisconnect($sessionId, $connectionId)
     {
         $request = new Request(
             'DELETE',
-            '/v2/project/'.$this->apiKey.'/session/'.$sessionId.'/connection/'.$connectionId,
+            '/v2/project/' . $this->apiKey . '/session/' . $sessionId . '/connection/' . $connectionId,
             ['Content-Type' => 'application/json']
         );
         try {
@@ -253,7 +247,7 @@ class Client
 
     public function listArchives($offset, $count, $sessionId)
     {
-        $request = new Request('GET', '/v2/project/'.$this->apiKey.'/archive');
+        $request = new Request('GET', '/v2/project/' . $this->apiKey . '/archive');
         $queryParams = [];
         if ($offset != 0) {
             $queryParams['offset'] = $offset;
@@ -281,7 +275,7 @@ class Client
     {
         $request = new Request(
             'POST',
-            '/v2/project/'.$this->apiKey.'/broadcast'
+            '/v2/project/' . $this->apiKey . '/broadcast'
         );
 
         $optionsJson = [
@@ -307,7 +301,7 @@ class Client
     {
         $request = new Request(
             'POST',
-            '/v2/project/'.$this->apiKey.'/broadcast/'.$broadcastId.'/stop',
+            '/v2/project/' . $this->apiKey . '/broadcast/' . $broadcastId . '/stop',
             ['Content-Type' => 'application/json']
         );
 
@@ -326,7 +320,7 @@ class Client
     {
         $request = new Request(
             'GET',
-            '/v2/project/'.$this->apiKey.'/broadcast/'.$broadcastId
+            '/v2/project/' . $this->apiKey . '/broadcast/' . $broadcastId
         );
         try {
             $response = $this->client->send($request, [
@@ -343,7 +337,7 @@ class Client
     {
         $request = new Request(
             'GET',
-            '/v2/project/'.$this->apiKey.'/'.$resourceType.'/'.$resourceId.'/layout'
+            '/v2/project/' . $this->apiKey . '/' . $resourceType . '/' . $resourceId . '/layout'
         );
         try {
             $response = $this->client->send($request, [
@@ -360,7 +354,7 @@ class Client
     {
         $request = new Request(
             'PUT',
-            '/v2/project/'.$this->apiKey.'/'.$resourceType.'/'.$resourceId.'/layout'
+            '/v2/project/' . $this->apiKey . '/' . $resourceType . '/' . $resourceId . '/layout'
         );
         try {
             $response = $this->client->send($request, [
@@ -378,7 +372,7 @@ class Client
     {
         $request = new Request(
             'PUT',
-            '/v2/project/'.$this->apiKey.'/archive/'.$archiveId.'/layout'
+            '/v2/project/' . $this->apiKey . '/archive/' . $archiveId . '/layout'
         );
         try {
             $response = $this->client->send($request, [
@@ -396,7 +390,7 @@ class Client
     {
         $request = new Request(
             'PUT',
-            '/v2/project/'.$this->apiKey.'/session/'.$sessionId.'/stream/'.$streamId
+            '/v2/project/' . $this->apiKey . '/session/' . $sessionId . '/stream/' . $streamId
         );
         try {
             $response = $this->client->send($request, [
@@ -411,10 +405,11 @@ class Client
         }
     }
 
-    public function getStream($sessionId, $streamId) {
+    public function getStream($sessionId, $streamId)
+    {
         $request = new Request(
             'GET',
-            '/v2/project/'.$this->apiKey.'/session/'.$sessionId.'/stream/'.$streamId
+            '/v2/project/' . $this->apiKey . '/session/' . $sessionId . '/stream/' . $streamId
         );
 
         try {
@@ -433,7 +428,7 @@ class Client
     {
         $request = new Request(
             'GET',
-            '/v2/project/'.$this->apiKey.'/session/'.$sessionId.'/stream/'
+            '/v2/project/' . $this->apiKey . '/session/' . $sessionId . '/stream/'
         );
         try {
             $response = $this->client->send($request, [
@@ -454,7 +449,7 @@ class Client
         );
         $request = new Request(
             'PUT',
-            'v2/project/'.$this->apiKey.'/session/'.$sessionId.'/stream'
+            'v2/project/' . $this->apiKey . '/session/' . $sessionId . '/stream'
         );
 
         try {
@@ -494,7 +489,7 @@ class Client
         }
 
         // set up the request
-        $request = new Request('POST', '/v2/project/'.$this->apiKey.'/call');
+        $request = new Request('POST', '/v2/project/' . $this->apiKey . '/call');
 
         try {
             $response = $this->client->send($request, [
@@ -508,14 +503,14 @@ class Client
         return $sipJson;
     }
 
-    public function signal($sessionId, $options=array(), $connectionId=null)
+    public function signal($sessionId, $options = array(), $connectionId = null)
     {
         // set up the request
 
         
-        $request = is_null($connectionId) || empty($connectionId) ? 
-                new Request('POST', '/v2/project/'.$this->apiKey.'/session/'.$sessionId.'/signal')
-                : new Request('POST', '/v2/project/'.$this->apiKey.'/session/'.$sessionId.'/connection/'.$connectionId.'/signal');
+        $request = is_null($connectionId) || empty($connectionId) ?
+                new Request('POST', '/v2/project/' . $this->apiKey . '/session/' . $sessionId . '/signal')
+                : new Request('POST', '/v2/project/' . $this->apiKey . '/session/' . $sessionId . '/connection/' . $connectionId . '/signal');
 
         try {
             $response = $this->client->send($request, [
@@ -565,12 +560,12 @@ class Client
                 );
             } else {
                 throw new DomainException(
-                    'The OpenTok API request failed: '. json_decode($e->getResponse()->getBody(true))->message,
+                    'The OpenTok API request failed: ' . json_decode($e->getResponse()->getBody(true))->message,
                     null,
                     $e
                 );
             }
-        } else if ($e instanceof ServerException) {
+        } elseif ($e instanceof ServerException) {
             // will catch all 5xx errors
             throw new UnexpectedValueException(
                 'The OpenTok API server responded with an error: ' . json_decode($e->getResponse()->getBody(true))->message,
@@ -618,7 +613,7 @@ class Client
     private function handleSignalingException($e)
     {
         $responseCode = $e->getResponse()->getStatusCode();
-        switch($responseCode) {
+        switch ($responseCode) {
             case 400:
                 $message = 'One of the signal properties — data, type, sessionId or connectionId — is invalid.';
                 throw new SignalUnexpectedValueException($message, $responseCode);
@@ -642,7 +637,7 @@ class Client
     private function handleForceDisconnectException($e)
     {
         $responseCode = $e->getResponse()->getStatusCode();
-        switch($responseCode) {
+        switch ($responseCode) {
             case 400:
                 $message = 'One of the arguments — sessionId or connectionId — is invalid.';
                 throw new ForceDisconnectUnexpectedValueException($message, $responseCode);
@@ -661,6 +656,6 @@ class Client
 
     private function isDebug()
     {
-      return defined('OPENTOK_DEBUG');
+        return defined('OPENTOK_DEBUG');
     }
 }

--- a/src/OpenTok/Util/Client.php
+++ b/src/OpenTok/Util/Client.php
@@ -2,6 +2,7 @@
 
 namespace OpenTok\Util;
 
+use function GuzzleHttp\default_user_agent;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Exception\ClientException;
@@ -54,7 +55,7 @@ class Client
         $clientOptions = [
             'base_uri' => $apiUrl,
             'headers' => [
-                'User-Agent' => OPENTOK_SDK_USER_AGENT . ' ' . \GuzzleHttp\default_user_agent(),
+                'User-Agent' => OPENTOK_SDK_USER_AGENT . ' ' . default_user_agent(),
             ],
         ];
 
@@ -617,18 +618,14 @@ class Client
             case 400:
                 $message = 'One of the signal properties — data, type, sessionId or connectionId — is invalid.';
                 throw new SignalUnexpectedValueException($message, $responseCode);
-                break;
             case 403:
                 throw new SignalAuthenticationException($this->apiKey, $this->apiSecret, null, $e);
-                break;
             case 404:
                 $message = 'The client specified by the connectionId property is not connected to the session.';
                 throw new SignalConnectionException($message, $responseCode);
-                break;
             case 413:
                 $message = 'The type string exceeds the maximum length (128 bytes), or the data string exceeds the maximum size (8 kB).';
                 throw new SignalUnexpectedValueException($message, $responseCode);
-                break;
             default:
                 break;
         }
@@ -641,14 +638,11 @@ class Client
             case 400:
                 $message = 'One of the arguments — sessionId or connectionId — is invalid.';
                 throw new ForceDisconnectUnexpectedValueException($message, $responseCode);
-                break;
             case 403:
                 throw new ForceDisconnectAuthenticationException($this->apiKey, $this->apiSecret, null, $e);
-                break;
             case 404:
                 $message = 'The client specified by the connectionId property is not connected to the session.';
                 throw new ForceDisconnectConnectionException($message, $responseCode);
-                break;
             default:
                 break;
         }

--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -18,9 +18,9 @@ use JohnStevenson\JsonWorks\Utils as JsonUtils;
 */
 class Validators
 {
-    static $guidRegEx = '/^\[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}\$/';
-    static $archiveSchemaUri;
-    static $broadcastSchemaUri;
+    public static $guidRegEx = '/^\[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}\$/';
+    public static $archiveSchemaUri;
+    public static $broadcastSchemaUri;
 
     public static function validateApiKey($apiKey)
     {

--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -9,9 +9,7 @@ use OpenTok\MediaMode;
 use OpenTok\ArchiveMode;
 use OpenTok\OutputMode;
 use OpenTok\OpenTok;
-
 use OpenTok\Exception\InvalidArgumentException;
-
 use JohnStevenson\JsonWorks\Document;
 use JohnStevenson\JsonWorks\Utils as JsonUtils;
 
@@ -28,21 +26,21 @@ class Validators
     {
         if (!(is_string($apiKey) || is_int($apiKey))) {
             throw new InvalidArgumentException(
-                'The apiKey was not a string nor an integer: '.print_r($apiKey, true)
+                'The apiKey was not a string nor an integer: ' . print_r($apiKey, true)
             );
         }
     }
     public static function validateApiSecret($apiSecret)
     {
         if (!(is_string($apiSecret))) {
-            throw new InvalidArgumentException('The apiSecret was not a string: '.print_r($apiSecret, true));
+            throw new InvalidArgumentException('The apiSecret was not a string: ' . print_r($apiSecret, true));
         }
     }
     public static function validateApiUrl($apiUrl)
     {
         if (!(is_string($apiUrl) && filter_var($apiUrl, FILTER_VALIDATE_URL))) {
             throw new InvalidArgumentException(
-                'The optional apiUrl was not a string: '.print_r($apiUrl, true)
+                'The optional apiUrl was not a string: ' . print_r($apiUrl, true)
             );
         }
     }
@@ -50,23 +48,23 @@ class Validators
     {
         if (isset($client) && !($client instanceof Client)) {
             throw new InvalidArgumentException(
-                'The optional client was not an instance of \OpenTok\Util\Client. client:'.print_r($client, true)
+                'The optional client was not an instance of \OpenTok\Util\Client. client:' . print_r($client, true)
             );
         }
     }
     public static function validateSessionId($sessionId)
     {
-        if(!is_string($sessionId) || empty($sessionId)){
+        if (!is_string($sessionId) || empty($sessionId)) {
             throw new InvalidArgumentException(
-                'Null or empty session ID is not valid: '.print_r($sessionId, true)
+                'Null or empty session ID is not valid: ' . print_r($sessionId, true)
             );
         }
     }
     public static function validateConnectionId($connectionId)
     {
-        if(!is_string($connectionId) || empty($connectionId)){
+        if (!is_string($connectionId) || empty($connectionId)) {
             throw new InvalidArgumentException(
-                'Null or empty connection ID is not valid: '.print_r($connectionId, true)
+                'Null or empty connection ID is not valid: ' . print_r($connectionId, true)
             );
         }
     }
@@ -74,35 +72,35 @@ class Validators
     public static function validateSignalPayload($payload)
     {
         list($type, $data) = array_values($payload);
-        if(!is_string($data) || is_null($data || is_null($type))){
+        if (!is_string($data) || is_null($data || is_null($type))) {
             throw new InvalidArgumentException(
-                'Signal Payload cannot be null: '.print_r($payload, true)
+                'Signal Payload cannot be null: ' . print_r($payload, true)
             );
         }
     }
     public static function validateRole($role)
     {
         if (!Role::isValidValue($role)) {
-            throw new InvalidArgumentException('Unknown role: '.print_r($role, true));
+            throw new InvalidArgumentException('Unknown role: ' . print_r($role, true));
         }
     }
     public static function validateExpireTime($expireTime, $createTime)
     {
-        if(!is_null($expireTime)) {
-            if(!is_numeric($expireTime)) {
+        if (!is_null($expireTime)) {
+            if (!is_numeric($expireTime)) {
                 throw new InvalidArgumentException(
-                    'Expire time must be a number: '.print_r($expireTime, true)
+                    'Expire time must be a number: ' . print_r($expireTime, true)
                 );
             }
-            if($expireTime < $createTime) {
+            if ($expireTime < $createTime) {
                 throw new InvalidArgumentException(
-                    'Expire time must be in the future: '.print_r($expireTime, true).'<'.print_r($createTime, true)
+                    'Expire time must be in the future: ' . print_r($expireTime, true) . '<' . print_r($createTime, true)
                 );
             }
             $in30Days = $createTime + 2592000;
-            if($expireTime > $in30Days) {
+            if ($expireTime > $in30Days) {
                 throw new InvalidArgumentException(
-                    'Expire time must be in the next 30 days: '.print_r($expireTime, true).'>'.$in30Days
+                    'Expire time must be in the next 30 days: ' . print_r($expireTime, true) . '>' . $in30Days
                 );
             }
         }
@@ -112,14 +110,14 @@ class Validators
         if ($data != null) {
             if (!is_string($data)) {
                 throw new InvalidArgumentException(
-                    'Connection data must be a string. data:'.print_r($data, true)
+                    'Connection data must be a string. data:' . print_r($data, true)
                 );
             }
-            if(!empty($data)) {
+            if (!empty($data)) {
                 $dataLength = strlen($data);
-                if($dataLength > 1000) {
+                if ($dataLength > 1000) {
                     throw new InvalidArgumentException(
-                        'Connection data must be less than 1000 characters. Length: '.$dataLength
+                        'Connection data must be less than 1000 characters. Length: ' . $dataLength
                     );
                 }
             }
@@ -129,7 +127,7 @@ class Validators
     {
         if ($name != null && !is_string($name) /* TODO: length? */) {
             throw new InvalidArgumentException(
-                'The name was not a string: '.print_r($name, true)
+                'The name was not a string: ' . print_r($name, true)
             );
         }
     }
@@ -137,7 +135,7 @@ class Validators
     {
         if (!is_bool($hasVideo)) {
             throw new InvalidArgumentException(
-                'The hasVideo was not a boolean: '.print_r($hasVideo, true)
+                'The hasVideo was not a boolean: ' . print_r($hasVideo, true)
             );
         }
     }
@@ -145,27 +143,29 @@ class Validators
     {
         if (!is_bool($hasAudio)) {
             throw new InvalidArgumentException(
-                'The hasAudio was not a boolean: '.print_r($hasAudio, true)
+                'The hasAudio was not a boolean: ' . print_r($hasAudio, true)
             );
         }
     }
     public static function validateArchiveOutputMode($outputMode)
     {
         if (!OutputMode::isValidValue($outputMode)) {
-            throw new InvalidArgumentException('Unknown output mode: '.print_r($outputMode, true));
+            throw new InvalidArgumentException('Unknown output mode: ' . print_r($outputMode, true));
         }
     }
     public static function validateArchiveId($archiveId)
     {
-        if ( !is_string($archiveId) || preg_match(self::$guidRegEx, $archiveId) ) {
+        if (!is_string($archiveId) || preg_match(self::$guidRegEx, $archiveId)) {
             throw new InvalidArgumentException(
-                'The archiveId was not valid. archiveId:'.print_r($archiveId, true)
+                'The archiveId was not valid. archiveId:' . print_r($archiveId, true)
             );
         }
     }
     public static function validateArchiveData($archiveData)
     {
-        if (!self::$archiveSchemaUri) { self::$archiveSchemaUri = __DIR__.'/archive-schema.json'; }
+        if (!self::$archiveSchemaUri) {
+            self::$archiveSchemaUri = __DIR__ . '/archive-schema.json';
+        }
         $document = new Document();
         // have to do a encode+decode so that json objects decoded as arrays from Guzzle
         // are re-encoded as objects instead
@@ -175,13 +175,15 @@ class Validators
         $document->loadSchema(JsonUtils::get(JsonUtils::get($document->schema->data, 'definitions'), 'archive'));
         if (!$document->validate()) {
             throw new InvalidArgumentException(
-                'The archive data provided is not valid. Errors:'.$document->lastError.' archiveData:'.print_r($archiveData, true)
+                'The archive data provided is not valid. Errors:' . $document->lastError . ' archiveData:' . print_r($archiveData, true)
             );
         }
     }
     public static function validateArchiveListData($archiveListData)
     {
-        if (!self::$archiveSchemaUri) { self::$archiveSchemaUri = __DIR__.'/archive-schema.json'; }
+        if (!self::$archiveSchemaUri) {
+            self::$archiveSchemaUri = __DIR__ . '/archive-schema.json';
+        }
         $document = new Document();
         // have to do a encode+decode so that json objects decoded as arrays from Guzzle
         // are re-encoded as objects instead
@@ -189,17 +191,18 @@ class Validators
         $document->loadSchema(self::$archiveSchemaUri);
         if (!$document->validate()) {
             throw new InvalidArgumentException(
-                'The archive data provided is not valid. Errors:'.$document->lastError.' archiveData:'.print_r($archiveListData, true)
+                'The archive data provided is not valid. Errors:' . $document->lastError . ' archiveData:' . print_r($archiveListData, true)
             );
         }
     }
     public static function validateOffsetAndCount($offset, $count)
     {
-        if ((!is_numeric($offset) || $offset < 0 ) ||
-            (($count != null && !is_numeric($count)) || $count < 0 || $count > 1000) ) {
-
+        if (
+            (!is_numeric($offset) || $offset < 0 ) ||
+            (($count != null && !is_numeric($count)) || $count < 0 || $count > 1000)
+        ) {
             throw new InvalidArgumentException(
-                'The offset or count were not valid numbers: offset='.print_r($offset, true).' count='.print_r($count, true)
+                'The offset or count were not valid numbers: offset=' . print_r($offset, true) . ' count=' . print_r($count, true)
             );
         }
     }
@@ -209,7 +212,7 @@ class Validators
         $sessionIdParts = self::decodeSessionId($sessionId);
         if (!in_array($apiKey, $sessionIdParts)) {
             throw new InvalidArgumentException(
-                'The sessionId must belong to the apiKey. sessionId: '.print_r($sessionId, true).', apiKey: '.print_r($apiKey, true)
+                'The sessionId must belong to the apiKey. sessionId: ' . print_r($sessionId, true) . ', apiKey: ' . print_r($apiKey, true)
             );
         }
     }
@@ -217,7 +220,7 @@ class Validators
     {
         if (!MediaMode::isValidValue($mediaMode)) {
             throw new InvalidArgumentException(
-                'The media mode option must be either \'MediaMode::ROUTED\' or \'MediaMode::RELAYED\'. mediaMode:'.print_r($mediaMode, true)
+                'The media mode option must be either \'MediaMode::ROUTED\' or \'MediaMode::RELAYED\'. mediaMode:' . print_r($mediaMode, true)
             );
         }
     }
@@ -225,7 +228,7 @@ class Validators
     {
         if (!ArchiveMode::isValidValue($archiveMode)) {
             throw new InvalidArgumentException(
-                'The archive mode option must be either \'ArchiveMode::MANUAL\' or \'ArchiveMode::ALWAYS\'. archiveMode:'.print_r($archiveMode, true)
+                'The archive mode option must be either \'ArchiveMode::MANUAL\' or \'ArchiveMode::ALWAYS\'. archiveMode:' . print_r($archiveMode, true)
             );
         }
     }
@@ -233,7 +236,7 @@ class Validators
     {
         if ($location != null && !filter_var($location, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
             throw new InvalidArgumentException(
-                'The location option must be an IPv4 address. location:'.print_r($location, true)
+                'The location option must be an IPv4 address. location:' . print_r($location, true)
             );
         }
     }
@@ -241,13 +244,15 @@ class Validators
     {
         if (!($opentok instanceof OpenTok)) {
             throw new InvalidArgumentException(
-                'The opentok parameter must be an instance of OpenTok\OpenTok. opentok:'.print_r($opentok, true)
+                'The opentok parameter must be an instance of OpenTok\OpenTok. opentok:' . print_r($opentok, true)
             );
         }
     }
     public static function validateBroadcastData($broadcastData)
     {
-        if (!self::$broadcastSchemaUri) { self::$broadcastSchemaUri = __DIR__.'/broadcast-schema.json'; }
+        if (!self::$broadcastSchemaUri) {
+            self::$broadcastSchemaUri = __DIR__ . '/broadcast-schema.json';
+        }
         $document = new Document();
         // have to do a encode+decode so that json objects decoded as arrays from Guzzle
         // are re-encoded as objects instead
@@ -255,15 +260,15 @@ class Validators
         $document->loadSchema(self::$broadcastSchemaUri);
         if (!$document->validate()) {
             throw new InvalidArgumentException(
-                'The broadcast data provided is not valid. Errors:'.$document->lastError.' broadcastData:'.print_r($broadcastData, true)
+                'The broadcast data provided is not valid. Errors:' . $document->lastError . ' broadcastData:' . print_r($broadcastData, true)
             );
         }
     }
     public static function validateBroadcastId($broadcastId)
     {
-        if ( !is_string($broadcastId) || preg_match(self::$guidRegEx, $broadcastId) ) {
+        if (!is_string($broadcastId) || preg_match(self::$guidRegEx, $broadcastId)) {
             throw new InvalidArgumentException(
-                'The broadcastId was not valid. broadcastId:'.print_r($broadcastId, true)
+                'The broadcastId was not valid. broadcastId:' . print_r($broadcastId, true)
             );
         }
     }
@@ -271,27 +276,27 @@ class Validators
     {
         if (!($layout instanceof Layout)) {
             throw new InvalidArgumentException(
-                'The layout parameter must be an instance of OpenTok\Layout. layout:'.print_r($layout, true)
+                'The layout parameter must be an instance of OpenTok\Layout. layout:' . print_r($layout, true)
             );
         }
     }
     public static function validateLayoutStylesheet($stylesheet)
     {
         if (!(is_string($stylesheet))) {
-            throw new InvalidArgumentException('The stylesheet was not a string: '.print_r($stylesheet, true));
+            throw new InvalidArgumentException('The stylesheet was not a string: ' . print_r($stylesheet, true));
         }
     }
     public static function validateStreamId($streamId)
     {
         if (!(is_string($streamId))) {
-            throw new InvalidArgumentException('The streamId was not a string: '.print_r($streamId, true));
+            throw new InvalidArgumentException('The streamId was not a string: ' . print_r($streamId, true));
         }
     }
     public static function validateLayoutClassList($layoutClassList, $format = 'JSON')
     {
         if ($format === 'JSON') {
             if (!is_array($layoutClassList) || self::isAssoc($layoutClassList)) {
-                throw new InvalidArgumentException('The layoutClassList was not a valid JSON array: '.print_r($layoutClassList, true));
+                throw new InvalidArgumentException('The layoutClassList was not a valid JSON array: ' . print_r($layoutClassList, true));
             }
         }
     }
@@ -306,7 +311,7 @@ class Validators
             throw new InvalidArgumentException('Each element in the streamClassArray must have a layoutClassList array.');
         }
         if (!is_array($layoutClassList['layoutClassList'])) {
-            throw new InvalidArgumentException('Each element in the layoutClassList array must be a string (defining class names).');            
+            throw new InvalidArgumentException('Each element in the layoutClassList array must be a string (defining class names).');
         }
     }
 
@@ -335,7 +340,7 @@ class Validators
         $trimmedSessionId = substr($sessionId, 2);
         $parts = explode('-', $trimmedSessionId);
         $data = array();
-        foreach($parts as $part) {
+        foreach ($parts as $part) {
             $decodedPart = base64_decode($part);
             $dataItems = explode('~', $decodedPart);
             $data = array_merge($data, $dataItems);

--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -348,5 +348,3 @@ class Validators
         return $data;
     }
 }
-
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/tests/OpenTokTest/ArchiveTest.php
+++ b/tests/OpenTokTest/ArchiveTest.php
@@ -312,4 +312,4 @@ class ArchiveTest extends TestCase
         $this->assertEquals($this->archiveData, $archiveArray);
     }
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/
+

--- a/tests/OpenTokTest/ArchiveTest.php
+++ b/tests/OpenTokTest/ArchiveTest.php
@@ -1,16 +1,16 @@
 <?php
 
+namespace OpenTokTest;
+
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
-
 use OpenTok\Archive;
-use OpenTok\OpenTokTestCase;
 use OpenTok\Util\Client;
+use PHPUnit\Framework\TestCase;
 
-use OpenTok\TestHelpers;
-
-class ArchiveTest extends PHPUnit_Framework_TestCase {
+class ArchiveTest extends TestCase
+{
 
     // Fixtures
     protected $archiveData;
@@ -230,11 +230,9 @@ class ArchiveTest extends PHPUnit_Framework_TestCase {
         $this->assertInstanceOf('OpenTok\Archive', $archive);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRejectsBadArchiveData()
     {
+        $this->expectException('InvalidArgumentException');
         $this->setupOT();
 
         // Set up fixtures
@@ -312,12 +310,6 @@ class ArchiveTest extends PHPUnit_Framework_TestCase {
         // Assert
         $this->assertInternalType('array', $archiveArray);
         $this->assertEquals($this->archiveData, $archiveArray);
-    }
-    // TODO: test deleted archive can not be stopped or deleted again
-
-    private function decodeToken($token)
-    {
-
     }
 }
 /* vim: set ts=4 sw=4 tw=100 sts=4 et :*/

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -1975,4 +1975,4 @@ class OpenTokTest extends TestCase
         new OpenTok('1234', 'abd', ['timeout' => -1]);
     }
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/
+

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -23,6 +23,9 @@ class OpenTokTest extends TestCase
     protected $API_KEY;
     protected $API_SECRET;
 
+    /**
+     * @var OpenTok
+     */
     protected $opentok;
     protected $client;
 
@@ -1604,18 +1607,15 @@ class OpenTokTest extends TestCase
         ]]);
 
         $sessionId = '1_MX4xMjM0NTY3OH4-VGh1IEZlYiAyNyAwNDozODozMSBQU1QgMjAxNH4wLjI0NDgyMjI';
-        $bogusApiKey = '12345678';
-        $bogusApiSecret = '0123456789abcdef0123456789abcdef0123456789';
         $bogusToken = 'T1==TEST';
         $bogusSipUri = 'sip:john@doe.com';
-        $opentok = new OpenTok($bogusApiKey, $bogusApiSecret);
 
         $from = "+0034123445566@opentok.me";
 
         // Act
-        $sipCall = $this->opentok->dial($sessionId, $bogusToken, $bogusSipUri, array(
+        $sipCall = $this->opentok->dial($sessionId, $bogusToken, $bogusSipUri, [
             'from' => $from
-        ));
+        ]);
 
         // Assert
         $this->assertInstanceOf('OpenTok\SipCall', $sipCall);

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -1,27 +1,24 @@
 <?php
 
+namespace OpenTokTest;
+
 use OpenTok\Role;
 use OpenTok\Layout;
-use OpenTok\Stream;
-
 use OpenTok\OpenTok;
-use OpenTok\Session;
 use OpenTok\MediaMode;
+use ArgumentCountError;
 use OpenTok\OutputMode;
-use OpenTok\StreamList;
 use OpenTok\ArchiveMode;
-use OpenTok\TestHelpers;
 use OpenTok\Util\Client;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\HandlerStack;
-
-use OpenTok\OpenTokTestCase;
+use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Handler\MockHandler;
 use OpenTok\Exception\InvalidArgumentException;
 
 define('OPENTOK_DEBUG', true);
 
-class OpenTokTest extends PHPUnit_Framework_TestCase
+class OpenTokTest extends TestCase
 {
     protected $API_KEY;
     protected $API_SECRET;
@@ -297,11 +294,9 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testFailsWhenCreatingRelayedAutoArchivedSession()
     {
+        $this->expectException('InvalidArgumentException');
         // Arrange
         $this->setupOT();
 
@@ -476,11 +471,9 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(hash_hmac('sha1', $decodedToken['dataString'], $bogusApiSecret), $decodedToken['sig']);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testFailsWhenGeneratingTokenUsingInvalidRole()
     {
+        $this->expectException('InvalidArgumentException');
         $this->setupOT();
         $token = $this->opentok->generateToken('SESSIONID', array('role' => 'notarole'));
     }
@@ -1056,11 +1049,9 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('832641bf-5dbf-41a1-ad94-fea213e59a92', $archiveList->getItems()[1]->id);        
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testFailsWhenListingArchivesWithTooLargeCount()
     {
+        $this->expectException('InvalidArgumentException');
         // Arrange
         $this->setupOTWithMocks([[
             'code' => 200,
@@ -1504,7 +1495,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         $this->assertNotNull($streamData->name);
         $this->assertNotNull($streamData->videoType);
         $this->assertNotNull($streamData->layoutClassList);
-        
+
         $userAgent = $request->getHeaderLine('User-Agent');
         $this->assertNotEmpty($userAgent);
         $this->assertStringStartsWith('OpenTok-PHP-SDK/4.5.0', $userAgent);
@@ -1735,9 +1726,9 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         $bogusApiKey = '12345678';
         $bogusApiSecret = '0123456789abcdef0123456789abcdef0123456789';
         $payload = array();
-        
+
         $opentok = new OpenTok($bogusApiKey, $bogusApiSecret);
-        
+
         // Act
         try {
             $this->opentok->signal($sessionId, $payload);
@@ -1760,9 +1751,9 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
             'type' => 'rest',
             'data' => 'random message'
         );
-        
+
         $opentok = new OpenTok($bogusApiKey, $bogusApiSecret);
-        
+
         $this->expectException('OpenTok\Exception\SignalConnectionException');
         // Act
         $this->opentok->signal($sessionId, $payload, $connectionId);
@@ -1783,14 +1774,14 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
             'type' => 'rest',
             'data' => 'more than 128 bytes'
         );
-        
+
         $opentok = new OpenTok($bogusApiKey, $bogusApiSecret);
-        
+
         $this->expectException('OpenTok\Exception\SignalUnexpectedValueException');
-        
+
         // Act
         $this->opentok->signal($sessionId, $payload, $connectionId);
-        
+
     }
 
     public function testListStreams()

--- a/tests/OpenTokTest/SessionTest.php
+++ b/tests/OpenTokTest/SessionTest.php
@@ -1,74 +1,35 @@
 <?php
 
+namespace OpenTokTest;
+
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
-
 use OpenTok\OpenTok;
-use OpenTok\OpenTokTestCase;
 use OpenTok\Session;
-use OpenTok\Stream;
-use OpenTok\StreamList;
 use OpenTok\MediaMode;
 use OpenTok\ArchiveMode;
-
-use OpenTok\TestHelpers;
 use OpenTok\Util\Client;
+use PHPUnit\Framework\TestCase;
 
-
-class SessionTest extends PHPUnit_Framework_TestCase
+class SessionTest extends TestCase
 {
     protected $API_KEY;
     protected $API_SECRET;
     protected $opentok;
 
     protected static $mockBasePath;
-    
+
     public static function setUpBeforeClass()
     {
         self::$mockBasePath = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR;
     }
-    
+
     public function setUp()
     {
         $this->API_KEY = defined('API_KEY') ? API_KEY : '12345678';
         $this->API_SECRET = defined('API_SECRET') ? API_SECRET : '0123456789abcdef0123456789abcdef0123456789';
         $this->opentok = new OpenTok($this->API_KEY, $this->API_SECRET);
-    }
-
-
-    private function setupOTWithMocks($mocks)
-    {
-        $this->API_KEY = defined('API_KEY') ? API_KEY : '12345678';
-        $this->API_SECRET = defined('API_SECRET') ? API_SECRET : '0123456789abcdef0123456789abcdef0123456789';
-
-        if (is_array($mocks)) {
-            $responses = TestHelpers::mocksToResponses($mocks, self::$mockBasePath);
-        } else {
-            $responses = [];
-        }
-
-        $mock = new MockHandler($responses);
-        $handlerStack = HandlerStack::create($mock);
-        $clientOptions = [
-            'handler' => $handlerStack
-        ];
-
-        $this->client = new Client();
-        $this->client->configure(
-            $this->API_KEY,
-            $this->API_SECRET,
-            'https://api.opentok.com',
-            $clientOptions
-        );
-
-        // Push history onto handler stack *after* configuring client to
-        // ensure auth header is added before history handler is invoked
-        $this->historyContainer = [];
-        $history = Middleware::history($this->historyContainer);
-        $handlerStack->push($history);
-
-        $this->opentok = new OpenTok($this->API_KEY, $this->API_SECRET, array('client' => $this->client));
     }
 
     public function testSessionWithId()
@@ -139,10 +100,10 @@ class SessionTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider badParameterProvider
-     * @expectedException InvalidArgumentException
      */
     public function testInitializationWithBadParams($sessionId, $props)
     {
+        $this->expectException('InvalidArgumentException');
         if (!$props || empty($props)) {
             $session = new Session($this->opentok, $sessionId);
         } else {

--- a/tests/OpenTokTest/SessionTest.php
+++ b/tests/OpenTokTest/SessionTest.php
@@ -165,4 +165,4 @@ class SessionTest extends TestCase
     }
 
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/
+

--- a/tests/OpenTokTest/TestHelpers.php
+++ b/tests/OpenTokTest/TestHelpers.php
@@ -79,4 +79,4 @@ class TestHelpers
         }, $mocks);
     }
 }
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/
+

--- a/tests/OpenTokTest/TestHelpers.php
+++ b/tests/OpenTokTest/TestHelpers.php
@@ -1,18 +1,19 @@
 <?php
 
-namespace OpenTok;
+namespace OpenTokTest;
 
 use GuzzleHttp\Psr7\Response;
 use \Firebase\JWT\JWT;
 
-class TestHelpers {
+class TestHelpers
+{
     // TODO: untested, unused
     public static function decodeSessionId($sessionId)
     {
         $trimmedSessionId = substr($sessionId, 2);
         $parts = explode('-', $trimmedSessionId);
         $data = array();
-        foreach($parts as $part) {
+        foreach ($parts as $part) {
             $decodedPart = base64_decode($part);
             $dataItems = explode('~', $decodedPart);
             $data = array_merge($data, $dataItems);
@@ -40,7 +41,7 @@ class TestHelpers {
 
         try {
             $decodedToken = JWT::decode($token, $apiSecret, array('HS256'));
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return false;
         }
 
@@ -71,7 +72,7 @@ class TestHelpers {
             $body = null;
             if (!empty($mock['body'])) {
                 $body = $mock['body'];
-            } else if (!empty($mock['path'])) {
+            } elseif (!empty($mock['path'])) {
                 $body = file_get_contents($basePath . $mock['path']);
             }
             return new Response($code, $headers, $body);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,4 +2,4 @@
 
 $loader = require __DIR__ . "/../vendor/autoload.php";
 $loader->addPsr4('OpenTok\\', __DIR__.'/OpenTok');
-/* vim: set ts=4 sw=4 tw=100 sts=4 et :*/
+


### PR DESCRIPTION
This is a change to prep some of the other work slated for Q3. In total this will be a breaking release once all the other work is finished, but to start off:

- Dropped support for PHP prior to 7.1, which brings this in line with the Nexmo SDK support
- Upgraded dependencies as far as they could be, with the language update
- Added additional dev dependencies for refactoring
- Syntax changes to bring it up to PSR-12 compliance
- Updates to unit tests to work with PHPUnit 7.4
- Removed and cleaned up a lot of `use` statements
- `OpenTok\OpenTok::dial()` required a small syntax change due to `null` no longer being countable

No code changes minus some syntax changes were done, so this is functionally equivalent to the existing release.