### PR TITLE
Upgrade to PHP7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ php:
 - 5.6
 - 7.0
 - 7.1
+- 7.2
+- 7.3
+- 7.4
 before_script:
 - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
 - travis_retry composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: trusty
 sudo: required
 language: php
 php:
-- 5.6
-- 7.0
 - 7.1
 - 7.2
 - 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-dist: trusty
-sudo: required
+os: linux
+dist: focal
 language: php
 php:
 - 7.1
@@ -7,7 +7,7 @@ php:
 - 7.3
 - 7.4
 before_script:
-- curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
+- curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-8.5.phar
 - travis_retry composer install
 script:
 - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: focal
+dist: bionic
 language: php
 php:
 - 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ os: linux
 dist: focal
 language: php
 php:
-- 7.1
 - 7.2
 - 7.3
 - 7.4

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It also includes methods for working with OpenTok
 [disconnecting clients from sessions](http://tokbox.com/developer/guides/moderation/rest/).
 
 ## Requirements
- * PHP >=7.1
+ * PHP >=7.2.5
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ It also includes methods for working with OpenTok
 [SIP interconnect](http://tokbox.com/developer/guides/sip), and
 [disconnecting clients from sessions](http://tokbox.com/developer/guides/moderation/rest/).
 
+## Requirements
+ * PHP >=7.1
+
 ## Installation
 
 ### Composer (recommended):
@@ -73,7 +76,7 @@ $options = [
     'apiUrl' => 'https://custom.domain.com/',
     'client' => new CustomOpenTokClient(),
     'timeout' => 10,
-]
+];
 $opentok = new OpenTok($apiKey, $apiSecret, $options);
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "issues": "https://github.com/opentok/Opentok-PHP-SDK/issues"
     },
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2.5",
         "ext-json": "*",
         "johnstevenson/json-works": "~1.1",
         "firebase/php-jwt": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": ">=5.6.0",
         "johnstevenson/json-works": "~1.1",
         "firebase/php-jwt": "^5.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "^7.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7",

--- a/composer.json
+++ b/composer.json
@@ -28,13 +28,14 @@
         "issues": "https://github.com/opentok/Opentok-PHP-SDK/issues"
     },
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.1",
+        "ext-json": "*",
         "johnstevenson/json-works": "~1.1",
         "firebase/php-jwt": "^5.0",
         "guzzlehttp/guzzle": "^7.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7",
+        "phpunit/phpunit": "^8.5",
         "phing/phing": "~2.16.0"
     },
     "autoload": {

--- a/src/OpenTok/Exception/GenericArchiveException.php
+++ b/src/OpenTok/Exception/GenericArchiveException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace OpenTok\Exception;
+
+/**
+ * Generic exception for calls to the archiving API.
+ */
+class GenericArchiveException extends \Exception implements ArchiveException
+{
+
+}

--- a/src/OpenTok/Exception/GenericBroadcastException.php
+++ b/src/OpenTok/Exception/GenericBroadcastException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace OpenTok\Exception;
+
+/**
+ * The class used for generic exceptions resulting from calls to the broadcast API.
+ */
+class GenericBroadcastException extends \Exception implements BroadcastException
+{
+
+}

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -37,7 +37,12 @@ class OpenTok {
     /** @internal */
     private $client;
 
-    /** @internal */
+    /**
+     * @param string $apiKey
+     * @param string $apiSecret
+     * @param array $options
+     * @internal
+     */
     public function __construct($apiKey, $apiSecret, $options = array())
     {
         // unpack optional arguments (merging with default values) into named variables

--- a/src/OpenTok/Util/Client.php
+++ b/src/OpenTok/Util/Client.php
@@ -7,6 +7,8 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Request;
+use OpenTok\Exception\GenericArchiveException;
+use OpenTok\Exception\GenericBroadcastException;
 use Psr\Http\Message\RequestInterface;
 use Firebase\JWT\JWT;
 
@@ -482,7 +484,7 @@ class Client
             )
         );
 
-        if (isset($options) && array_key_exists('headers', $options) && sizeof($options['headers']) > 0) {
+        if (isset($options) && array_key_exists('headers', $options) && is_array($options['headers']) && count($options['headers']) > 0) {
             $body['sip']['headers'] = $options['headers'];
         }
 
@@ -594,8 +596,7 @@ class Client
         } catch (UnexpectedValueException $uve) {
             throw new ArchiveUnexpectedValueException($e->getMessage(), null, $uve->getPrevious());
         } catch (Exception $oe) {
-            // TODO: check if this works because ArchiveException is an interface not a class
-            throw new ArchiveException($e->getMessage(), null, $oe->getPrevious());
+            throw new GenericArchiveException($e->getMessage(), null, $oe->getPrevious());
         }
     }
 
@@ -611,7 +612,7 @@ class Client
             throw new BroadcastUnexpectedValueException($e->getMessage(), null, $uve->getPrevious());
         } catch (Exception $oe) {
             // TODO: check if this works because BroadcastException is an interface not a class
-            throw new BroadcastException($e->getMessage(), null, $oe->getPrevious());
+            throw new GenericBroadcastException($e->getMessage(), null, $oe->getPrevious());
         }
     }
 

--- a/tests/OpenTok/ArchiveTest.php
+++ b/tests/OpenTok/ArchiveTest.php
@@ -9,8 +9,9 @@ use OpenTok\OpenTokTestCase;
 use OpenTok\Util\Client;
 
 use OpenTok\TestHelpers;
+use PHPUnit\Framework\TestCase;
 
-class ArchiveTest extends PHPUnit_Framework_TestCase {
+class ArchiveTest extends TestCase {
 
     // Fixtures
     protected $archiveData;
@@ -22,7 +23,7 @@ class ArchiveTest extends PHPUnit_Framework_TestCase {
 
     protected static $mockBasePath;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() :void
     {
         self::$mockBasePath = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR;
     }
@@ -230,11 +231,9 @@ class ArchiveTest extends PHPUnit_Framework_TestCase {
         $this->assertInstanceOf('OpenTok\Archive', $archive);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRejectsBadArchiveData()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->setupOT();
 
         // Set up fixtures
@@ -296,7 +295,7 @@ class ArchiveTest extends PHPUnit_Framework_TestCase {
         $archiveJson = $this->archive->toJson();
 
         // Assert
-        $this->assertInternalType('string', $archiveJson);
+        $this->assertIsString($archiveJson);
         $this->assertNotNull(json_encode($archiveJson));
     }
 
@@ -310,7 +309,7 @@ class ArchiveTest extends PHPUnit_Framework_TestCase {
         $archiveArray = $this->archive->toArray();
 
         // Assert
-        $this->assertInternalType('array', $archiveArray);
+        $this->assertIsArray($archiveArray);
         $this->assertEquals($this->archiveData, $archiveArray);
     }
     // TODO: test deleted archive can not be stopped or deleted again

--- a/tests/OpenTok/OpenTokTest.php
+++ b/tests/OpenTok/OpenTokTest.php
@@ -18,10 +18,11 @@ use GuzzleHttp\HandlerStack;
 use OpenTok\OpenTokTestCase;
 use GuzzleHttp\Handler\MockHandler;
 use OpenTok\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
 define('OPENTOK_DEBUG', true);
 
-class OpenTokTest extends PHPUnit_Framework_TestCase
+class OpenTokTest extends TestCase
 {
     protected $API_KEY;
     protected $API_SECRET;
@@ -31,7 +32,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
 
     protected static $mockBasePath;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         self::$mockBasePath = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR;
     }
@@ -297,11 +298,9 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testFailsWhenCreatingRelayedAutoArchivedSession()
     {
+        $this->expectException(InvalidArgumentException::class);
         // Arrange
         $this->setupOT();
 
@@ -328,7 +327,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         $token = $opentok->generateToken($sessionId);
 
         // Assert
-        $this->assertInternalType('string', $token);
+        $this->assertIsString($token);
 
         $decodedToken = TestHelpers::decodeToken($token);
         $this->assertEquals($sessionId, $decodedToken['session_id']);
@@ -359,7 +358,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         $token = $opentok->generateToken($sessionId, array('role' => Role::MODERATOR));
 
         // Assert
-        $this->assertInternalType('string', $token);
+        $this->assertIsString($token);
 
         $decodedToken = TestHelpers::decodeToken($token);
         $this->assertEquals($sessionId, $decodedToken['session_id']);
@@ -391,7 +390,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         $token = $opentok->generateToken($sessionId, array('expireTime' => $inOneHour ));
 
         // Assert
-        $this->assertInternalType('string', $token);
+        $this->assertIsString($token);
 
         $decodedToken = TestHelpers::decodeToken($token);
         $this->assertEquals($sessionId, $decodedToken['session_id']);
@@ -421,7 +420,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         $token = $opentok->generateToken($sessionId, array('data' => $userStatus ));
 
         // Assert
-        $this->assertInternalType('string', $token);
+        $this->assertIsString($token);
 
         $decodedToken = TestHelpers::decodeToken($token);
         $this->assertEquals($sessionId, $decodedToken['session_id']);
@@ -458,7 +457,7 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         ));
 
         // Assert
-        $this->assertInternalType('string', $token);
+        $this->assertIsString($token);
 
         $decodedToken = TestHelpers::decodeToken($token);
         $this->assertEquals($sessionId, $decodedToken['session_id']);
@@ -476,11 +475,9 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(hash_hmac('sha1', $decodedToken['dataString'], $bogusApiSecret), $decodedToken['sig']);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testFailsWhenGeneratingTokenUsingInvalidRole()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->setupOT();
         $token = $this->opentok->generateToken('SESSIONID', array('role' => 'notarole'));
     }
@@ -1056,11 +1053,9 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('832641bf-5dbf-41a1-ad94-fea213e59a92', $archiveList->getItems()[1]->id);        
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testFailsWhenListingArchivesWithTooLargeCount()
     {
+        $this->expectException(InvalidArgumentException::class);
         // Arrange
         $this->setupOTWithMocks([[
             'code' => 200,
@@ -1196,12 +1191,12 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         $this->assertStringStartsWith('OpenTok-PHP-SDK/4.5.0', $userAgent);
 
         $this->assertInstanceOf('OpenTok\Broadcast', $broadcast);
-        $this->assertInternalType('string', $broadcast->id);
+        $this->assertIsString($broadcast->id);
         $this->assertEquals($sessionId, $broadcast->sessionId);
-        $this->assertInternalType('array', $broadcast->broadcastUrls);
+        $this->assertIsArray($broadcast->broadcastUrls);
         $this->assertArrayHasKey('hls', $broadcast->broadcastUrls);
-        $this->assertInternalType('string', $broadcast->broadcastUrls['hls']);
-        $this->assertInternalType('string', $broadcast->hlsUrl);
+        $this->assertIsString($broadcast->broadcastUrls['hls']);
+        $this->assertIsString($broadcast->hlsUrl);
         $this->assertFalse($broadcast->isStopped);
     }
 
@@ -1252,14 +1247,14 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
         $this->assertStringStartsWith('OpenTok-PHP-SDK/4.5.0', $userAgent);
 
         $this->assertInstanceOf('OpenTok\Broadcast', $broadcast);
-        $this->assertInternalType('string', $broadcast->id);
+        $this->assertIsString($broadcast->id);
         $this->assertEquals($sessionId, $broadcast->sessionId);
         $this->assertEquals($maxDuration, $broadcast->maxDuration);
-        $this->assertEquals($resolution, $broadcast->resolution);        
-        $this->assertInternalType('array', $broadcast->broadcastUrls);
+        $this->assertEquals($resolution, $broadcast->resolution);
+        $this->assertIsArray($broadcast->broadcastUrls);
         $this->assertArrayHasKey('hls', $broadcast->broadcastUrls);
-        $this->assertInternalType('string', $broadcast->broadcastUrls['hls']);
-        $this->assertInternalType('string', $broadcast->hlsUrl);
+        $this->assertIsString($broadcast->broadcastUrls['hls']);
+        $this->assertIsString($broadcast->hlsUrl);
         $this->assertFalse($broadcast->isStopped);
     }
 
@@ -1743,6 +1738,8 @@ class OpenTokTest extends PHPUnit_Framework_TestCase
             $this->opentok->signal($sessionId, $payload);
         } catch (\Exception $e) {
         }
+
+        $this->expectNotToPerformAssertions();
     }
 
     public function testSignalConnectionException()

--- a/tests/OpenTok/SessionTest.php
+++ b/tests/OpenTok/SessionTest.php
@@ -14,9 +14,10 @@ use OpenTok\ArchiveMode;
 
 use OpenTok\TestHelpers;
 use OpenTok\Util\Client;
+use PHPUnit\Framework\TestCase;
 
 
-class SessionTest extends PHPUnit_Framework_TestCase
+class SessionTest extends TestCase
 {
     protected $API_KEY;
     protected $API_SECRET;
@@ -24,12 +25,12 @@ class SessionTest extends PHPUnit_Framework_TestCase
 
     protected static $mockBasePath;
     
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$mockBasePath = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR;
     }
     
-    public function setUp()
+    public function setUp(): void
     {
         $this->API_KEY = defined('API_KEY') ? API_KEY : '12345678';
         $this->API_SECRET = defined('API_SECRET') ? API_SECRET : '0123456789abcdef0123456789abcdef0123456789';
@@ -139,10 +140,10 @@ class SessionTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider badParameterProvider
-     * @expectedException InvalidArgumentException
      */
     public function testInitializationWithBadParams($sessionId, $props)
     {
+        $this->expectException(InvalidArgumentException::class);
         if (!$props || empty($props)) {
             $session = new Session($this->opentok, $sessionId);
         } else {
@@ -187,7 +188,7 @@ class SessionTest extends PHPUnit_Framework_TestCase
 
         $token = $session->generateToken();
 
-        $this->assertInternalType('string', $token);
+        $this->assertIsString($token);
         $decodedToken = TestHelpers::decodeToken($token);
         $this->assertEquals($sessionId, $decodedToken['session_id']);
         $this->assertEquals($bogusApiKey, $decodedToken['partner_id']);


### PR DESCRIPTION
This PR should point to a new version as ends compatibility with PHP5.6, 7.0 and 7.1.

Upgrades to:
 - PHP >= 7.2.5
 - Guzzle ^7.0.1
 - PhpUnit ^8.0

Update tests to version changes.