### PR TITLE
Bumped Guzzle version to include ~7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": ">=5.6.0",
         "johnstevenson/json-works": "~1.1",
         "firebase/php-jwt": "^5.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~6.0|~7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7",


### PR DESCRIPTION
Addressing issue #271, I have bumped the version of Guzzle to include ~7.0 to allow the SDK to be used with modern frameworks such as Laravel.

Locally I had three tests failing before making this change and the three same tests failed for the same reason after making the change so I don't believe the Guzzle version bump has caused the failing tests.

```
1) OpenTokTest::testSipCall
sizeof(): Parameter must be an array or an object that implements Countable

2) OpenTokTest::testSipCallWithAuth
sizeof(): Parameter must be an array or an object that implements Countable

3) OpenTokTest::testSipCallFrom
sizeof(): Parameter must be an array or an object that implements Countable
```