### PR TITLE
Added more error handling around signal HTTP errors

### DIFF
--- a/src/OpenTok/Exception/SignalNetworkConnectionException.php
+++ b/src/OpenTok/Exception/SignalNetworkConnectionException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OpenTok\Exception;
+
+/**
+* Defines an exception thrown when a call to a signal method results in no
+* response from the server
+*/
+class SignalNetworkConnectionException extends \RuntimeException implements SignalException
+{
+
+}

--- a/tests/OpenTokTest/Utils/ClientTest.php
+++ b/tests/OpenTokTest/Utils/ClientTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace OpenTokTest\Util;
+
+use GuzzleHttp\Client as GuzzleHttpClient;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use OpenTok\Exception\SignalAuthenticationException;
+use OpenTok\Exception\SignalConnectionException;
+use OpenTok\Exception\SignalNetworkConnectionException;
+use OpenTok\Exception\SignalUnexpectedValueException;
+use OpenTok\Util\Client;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+
+class ClientTest extends TestCase
+{
+    public function testHandlesSignalErrorHandlesNoResponse()
+    {
+        $this->expectException(SignalNetworkConnectionException::class);
+        $this->expectExceptionMessage('Unable to communicate with host');
+
+        $mock = new MockHandler([
+            new RequestException('Unable to communicate with host', new Request('GET', 'signals')),
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $guzzle = new GuzzleHttpClient(['handler' => $handlerStack]);
+
+        $client = new Client();
+        $client->configure('asdf', 'asdf', 'http://localhost/', ['client' => $guzzle]);
+        $client->signal('sessionabcd', ['type' => 'foo', 'data' => 'bar'], 'connection1234');
+    }
+
+    public function testHandlesSignalErrorHandles400Response()
+    {
+        $this->expectException(SignalUnexpectedValueException::class);
+
+        $mock = new MockHandler([
+            $this->getResponse('signal-failure-payload', 400)
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $guzzle = new GuzzleHttpClient(['handler' => $handlerStack]);
+
+        $client = new Client();
+        $client->configure('asdf', 'asdf', 'http://localhost/', ['client' => $guzzle]);
+        $client->signal('sessionabcd', ['type' => 'foo', 'data' => 'bar'], 'connection1234');
+    }
+
+    public function testHandlesSignalErrorHandles403Response()
+    {
+        $this->expectException(SignalAuthenticationException::class);
+
+        $mock = new MockHandler([
+            $this->getResponse('signal-failure-invalid-token', 403)
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $guzzle = new GuzzleHttpClient(['handler' => $handlerStack]);
+
+        $client = new Client();
+        $client->configure('asdf', 'asdf', 'http://localhost/', ['client' => $guzzle]);
+        $client->signal('sessionabcd', ['type' => 'foo', 'data' => 'bar'], 'connection1234');
+    }
+
+    public function testHandlesSignalErrorHandles404Response()
+    {
+        $this->expectException(SignalConnectionException::class);
+        $this->expectExceptionMessage('The client specified by the connectionId property is not connected to the session.');
+
+        $mock = new MockHandler([
+            $this->getResponse('signal-failure-no-clients', 404)
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $guzzle = new GuzzleHttpClient(['handler' => $handlerStack]);
+
+        $client = new Client();
+        $client->configure('asdf', 'asdf', 'http://localhost/', ['client' => $guzzle]);
+        $client->signal('sessionabcd', ['type' => 'foo', 'data' => 'bar'], 'connection1234');
+    }
+
+    public function testHandlesSignalErrorHandles413Response()
+    {
+        $this->expectException(SignalUnexpectedValueException::class);
+        $this->expectExceptionMessage('The type string exceeds the maximum length (128 bytes), or the data string exceeds the maximum size (8 kB).');
+
+        $mock = new MockHandler([
+            $this->getResponse('signal-failure', 413)
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $guzzle = new GuzzleHttpClient(['handler' => $handlerStack]);
+
+        $client = new Client();
+        $client->configure('asdf', 'asdf', 'http://localhost/', ['client' => $guzzle]);
+        $client->signal('sessionabcd', ['type' => 'foo', 'data' => 'bar'], 'connection1234');
+    }
+
+    /**
+     * Get the API response we'd expect for a call to the API.
+     */
+    protected function getResponse(string $type = 'success', int $status = 200): Response
+    {
+        return new Response(
+            $status,
+            ['Content-Type' => 'application/json'],
+            fopen(__DIR__ . '/responses/' . $type . '.json', 'rb')
+        );
+    }
+}

--- a/tests/OpenTokTest/Utils/responses/signal-failure-invalid-token.json
+++ b/tests/OpenTokTest/Utils/responses/signal-failure-invalid-token.json
@@ -1,0 +1,5 @@
+{
+    "code": -1,
+    "message": "Id in the token does not match the one in the url",
+    "description": "Id in the token does not match the one in the url"
+  }

--- a/tests/OpenTokTest/Utils/responses/signal-failure-no-clients.json
+++ b/tests/OpenTokTest/Utils/responses/signal-failure-no-clients.json
@@ -1,0 +1,3 @@
+{
+    "message": "Not found. No clients are actively connected to the OpenTok session."
+}

--- a/tests/OpenTokTest/Utils/responses/signal-failure-payload.json
+++ b/tests/OpenTokTest/Utils/responses/signal-failure-payload.json
@@ -1,0 +1,5 @@
+{
+    "code": 15202,
+    "message": "Signal payload 'data' must be set",
+    "description": "Signal payload 'data' must be set"
+  }

--- a/tests/OpenTokTest/Utils/responses/signal-failure.json
+++ b/tests/OpenTokTest/Utils/responses/signal-failure.json
@@ -1,0 +1,5 @@
+{
+    "code": -99,
+    "message": "Unknown error",
+    "description": "An unknown error occurred"
+  }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This adds some additional error handling and type checking around Signal responses. As a way to test, this also lets a custom Guzzle client be passed into the system via the options. This should fix #276 

## Description
<!--- Describe your changes in detail -->

### Signal Exceptions
Previously the SDK just checked for a generic `\Exception` being thrown, but then in the error handler was calling methods that exist only on certain Guzzle exceptions. This expands the exception handling to look for `GuzzleHttp\Exception\ClientException`, which was what the previous error handler expected, `GuzzleHttp\Exception\RequestException`, which seems to be the underlying cause of #276, and finally generic `\Exception`.

If a `RequestException` is encountered, we wrap that in a new `OpenTok\Exception\SignalNetworkConnectionException` so that client applications can now catch it. All other `\Exception`s being thrown are bubbled up so they can be caught at the application layer (and hopefully be reported back to us).

### Custom Guzzle Client
To facilitate the testing of this, a way was needed to pass in a test Guzzle client. A user can now create their own `OpenTok\Util\Client` and pass in a `client` key as an option:

```php
$guzzle = new \GuzzleHttp\Client();

$client = new \OpenTok\Util\Client();
$client->configure('asdf', 'asdf', 'http://localhost/', ['client' => $guzzle]);
```

As of the time of this issue, we still only support clients that are compatible with `GuzzleHttp\Client`, but this opens up the ability for users to set more concrete options on a Guzzle client and have them passed into the system.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Per #276, the user's application was running into a situation where there was no Request on signal exceptions. Additional testing showed that one route would be that there is a connection issue between their application and us, resulting in a connection error. The new error handling wrapping should be detect this and throw the exception in a way that the user's application can handle it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests to simulate failed connections.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
