### PR TITLE
Adding Screenshare Layout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ You can set change the layout dynamically, using the
 ```php
 use OpenTok\OpenTok;
 
-$layout Layout::getPIP(); // Or use another get method of the Layout class.
+$layout = Layout::getPIP(); // Or use another get method of the Layout class.
 $opentok->updateBroadcastLayout($broadcastId, $layout);
 ```
 
@@ -336,6 +336,13 @@ $options = array(
 
 $layoutType = Layout::createCustom($options);
 $opentok->setArchiveLayout($archiveId, $layoutType);
+```
+
+You can also set the Screenshare Layout by calling the `setScreenshareType()` method on a layout object.
+
+```php
+$layout = Layout::getBestFit(); // Other types are not currently supported
+$layout->setScreenshareType(Layout::LAYOUT_VERTICAL);
 ```
 
 You can set the initial layout class for a client's streams by setting the `layout` option when

--- a/src/OpenTok/Layout.php
+++ b/src/OpenTok/Layout.php
@@ -19,61 +19,32 @@ use OpenTok\Util\Validators;
  * <a href="https://tokbox.com/developer/guides/broadcast/live-streaming/#configuring-video-layout-for-opentok-live-streaming-broadcasts">Configuring
  * video layout for OpenTok live streaming broadcasts</a>.
  */
-class Layout
+class Layout implements \JsonSerializable
 {
-    // NOTE: after PHP 5.3.0 support is dropped, the class can implement JsonSerializable
-
-    /** @ignore */
-    private static $bestFit;
-    /** @ignore */
-    private static $pip;
-    /** @ignore */
-    private static $verticalPresentation;
-    /** @ignore */
-    private static $horizontalPresentation;
+    public const LAYOUT_BESTFIT = 'bestFit';
+    public const LAYOUT_PIP = 'pip';
+    public const LAYOUT_VERTICAL = 'verticalPresentation';
+    public const LAYOUT_HORIZONTAL = 'horizontalPresentation';
 
     /**
-     * Returns a Layout object defining the "best fit" predefined layout type.
-     */
-    public static function getBestFit()
-    {
-        if (is_null(self::$bestFit)) {
-            self::$bestFit = new Layout('bestFit');
-        }
-        return self::$bestFit;
-    }
+     * Type of layout that we are sending
+     * @var string
+     * @ignore
+     * */
+    private $type;
 
     /**
-     * Returns a Layout object defining the "picture-in-picture" predefined layout type.
+     * Custom stylesheet if our type is 'custom'
+     * @var string
+     * @ignore
      */
-    public static function getPIP()
-    {
-        if (is_null(self::$pip)) {
-            self::$pip = new Layout('pip');
-        }
-        return self::$pip;
-    }
+    private $stylesheet;
 
-    /**
-     * Returns a Layout object defining the "vertical presentation" predefined layout type.
-     */
-    public static function getVerticalPresentation()
+    /** @ignore */
+    private function __construct(string $type, ?string $stylesheet = null)
     {
-        if (is_null(self::$verticalPresentation)) {
-            self::$verticalPresentation = new Layout('verticalPresentation');
-        }
-        return self::$verticalPresentation;
-    }
-
-    /**
-     * Returns a Layout object defining the "horizontal presentation" predefined layout type.
-     */
-    public static function getHorizontalPresentation()
-    {
-        if (is_null(self::$horizontalPresentation)) {
-            self::$horizontalPresentation = new Layout('horizontalPresentation');
-        }
-        return self::$horizontalPresentation;
+        $this->type = $type;
+        $this->stylesheet = $stylesheet;
     }
 
     /**
@@ -82,7 +53,7 @@ class Layout
      * @param array $options An array containing one property: <code>$stylesheet<code>,
      * which is a string containing the stylesheet to be used for the layout.
      */
-    public static function createCustom($options)
+    public static function createCustom(array $options): Layout
     {
         // unpack optional arguments (merging with default values) into named variables
         // NOTE: the default value of stylesheet=null will not pass validation, this essentially
@@ -99,28 +70,61 @@ class Layout
     }
 
     /** @ignore */
-    public static function fromData($layoutData)
+    public static function fromData(array $layoutData): Layout
     {
         if (array_key_exists('stylesheet', $layoutData)) {
             return new Layout($layoutData['type'], $layoutData['stylesheet']);
-        } else {
-            return new Layout($layoutData['type']);
         }
+
+        return new Layout($layoutData['type']);
     }
 
-    /** @ignore */
-    private $type;
-    /** @ignore */
-    private $stylesheet;
-
-    /** @ignore */
-    private function __construct($type, $stylesheet = null)
+    /**
+     * Returns a Layout object defining the "best fit" predefined layout type.
+     */
+    public static function getBestFit(): Layout
     {
-        $this->type = $type;
-        $this->stylesheet = $stylesheet;
+        return new Layout(static::LAYOUT_BESTFIT);
+    }
+
+    /**
+     * Returns a Layout object defining the "picture-in-picture" predefined layout type.
+     */
+    public static function getPIP(): Layout
+    {
+        return new Layout(static::LAYOUT_PIP);
+    }
+
+    /**
+     * Returns a Layout object defining the "vertical presentation" predefined layout type.
+     */
+    public static function getVerticalPresentation(): Layout
+    {
+        return new Layout(static::LAYOUT_VERTICAL);
+    }
+
+    /**
+     * Returns a Layout object defining the "horizontal presentation" predefined layout type.
+     */
+    public static function getHorizontalPresentation(): Layout
+    {
+        return new Layout(static::LAYOUT_HORIZONTAL);
     }
 
     public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Return a json-encoded string representation of the layout
+     */
+    public function toJson(): string
+    {
+        return json_encode($this->jsonSerialize());
+    }
+
+    public function toArray(): array
     {
         $data = array(
             'type' => $this->type
@@ -131,10 +135,5 @@ class Layout
             $data['stylesheet'] = $this->stylesheet;
         }
         return $data;
-    }
-
-    public function toJson()
-    {
-        return json_encode($this->jsonSerialize());
     }
 }

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -2,10 +2,11 @@
 
 namespace OpenTok;
 
+use OpenTok\Layout;
 use OpenTok\Util\Client;
 use OpenTok\Util\Validators;
-use OpenTok\Exception\UnexpectedValueException;
 use OpenTok\Exception\InvalidArgumentException;
+use OpenTok\Exception\UnexpectedValueException;
 
 /**
 * Contains methods for creating OpenTok sessions, generating tokens, and working with archives.
@@ -296,13 +297,17 @@ class OpenTok
      * @return Archive The Archive object, which includes properties defining the archive, including
      * the archive ID.
      */
-    public function startArchive($sessionId, $options = array())
+    public function startArchive(string $sessionId, $options = []): Archive
     {
         // support for deprecated method signature, remove in v3.0.0 (not before)
         if (!is_array($options)) {
+            trigger_error(
+                'Archive options passed as a string is deprecated, please pass an array with a name key',
+                E_USER_DEPRECATED
+            );
             $options = array('name' => $options);
         }
-        
+
         // unpack optional arguments (merging with default values) into named variables
         $defaults = array(
             'name' => null,
@@ -425,17 +430,11 @@ class OpenTok
 
     /**
      * Updates the stream layout in an OpenTok Archive.
-     *
-     * @param string $archiveId The OpenTok archive ID.
-     *
-     * @param string $layout The connectionId of the connection in a session.
      */
-
-    public function setArchiveLayout($archiveId, $layoutType)
+    public function setArchiveLayout(string $archiveId, Layout $layoutType): void
     {
         Validators::validateArchiveId($archiveId);
-        Validators::validateLayout($layoutType);
-        
+
         $this->client->setArchiveLayout($archiveId, $layoutType);
     }
 
@@ -497,7 +496,7 @@ class OpenTok
      *
      * @return Broadcast An object with properties defining the broadcast.
      */
-    public function startBroadcast($sessionId, $options = array())
+    public function startBroadcast(string $sessionId, array $options = []): Broadcast
     {
         // unpack optional arguments (merging with default values) into named variables
         // NOTE: although the server can be authoritative about the default value of layout, its
@@ -571,14 +570,9 @@ class OpenTok
      *
      * @param Layout $layout An object defining the layout type for the broadcast.
      */
-    public function updateBroadcastLayout($broadcastId, $layout)
+    public function updateBroadcastLayout(string $broadcastId, Layout $layout): void
     {
         Validators::validateBroadcastId($broadcastId);
-        Validators::validateLayout($layout);
-
-        // TODO: platform implementation does not meet API Review spec
-        // $layoutData = $this->client->updateLayout($broadcastId, $layout, 'broadcast');
-        // return Layout::fromData($layoutData);
 
         $this->client->updateLayout($broadcastId, $layout, 'broadcast');
     }

--- a/src/OpenTok/Util/Client.php
+++ b/src/OpenTok/Util/Client.php
@@ -2,36 +2,37 @@
 
 namespace OpenTok\Util;
 
+use OpenTok\Layout;
+use Firebase\JWT\JWT;
+use OpenTok\MediaMode;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Request;
-use Psr\Http\Message\RequestInterface;
-use Firebase\JWT\JWT;
-use GuzzleHttp\Exception\RequestException;
 use OpenTok\Exception\Exception;
 use OpenTok\Exception\DomainException;
-use OpenTok\Exception\UnexpectedValueException;
-use OpenTok\Exception\AuthenticationException;
+use Psr\Http\Message\RequestInterface;
 use OpenTok\Exception\ArchiveException;
-use OpenTok\Exception\ArchiveDomainException;
-use OpenTok\Exception\ArchiveUnexpectedValueException;
-use OpenTok\Exception\ArchiveAuthenticationException;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
 use OpenTok\Exception\BroadcastException;
-use OpenTok\Exception\BroadcastDomainException;
-use OpenTok\Exception\BroadcastUnexpectedValueException;
-use OpenTok\Exception\BroadcastAuthenticationException;
-use OpenTok\Exception\SignalConnectionException;
-use OpenTok\Exception\SignalUnexpectedValueException;
-use OpenTok\Exception\SignalAuthenticationException;
-use OpenTok\Exception\ForceDisconnectConnectionException;
-use OpenTok\Exception\ForceDisconnectUnexpectedValueException;
-use OpenTok\Exception\ForceDisconnectAuthenticationException;
-use OpenTok\Exception\SignalNetworkConnectionException;
-use OpenTok\MediaMode;
-
+use GuzzleHttp\Exception\RequestException;
 use function GuzzleHttp\default_user_agent;
+use OpenTok\Exception\ArchiveDomainException;
+use OpenTok\Exception\AuthenticationException;
+use OpenTok\Exception\BroadcastDomainException;
+use OpenTok\Exception\UnexpectedValueException;
+use OpenTok\Exception\SignalConnectionException;
+use OpenTok\Exception\SignalAuthenticationException;
+use OpenTok\Exception\ArchiveAuthenticationException;
+use OpenTok\Exception\SignalUnexpectedValueException;
+use OpenTok\Exception\ArchiveUnexpectedValueException;
+use OpenTok\Exception\BroadcastAuthenticationException;
+use OpenTok\Exception\SignalNetworkConnectionException;
+use OpenTok\Exception\BroadcastUnexpectedValueException;
+use OpenTok\Exception\ForceDisconnectConnectionException;
+
+use OpenTok\Exception\ForceDisconnectAuthenticationException;
+use OpenTok\Exception\ForceDisconnectUnexpectedValueException;
 
 // TODO: build this dynamically
 /** @internal */
@@ -154,18 +155,15 @@ class Client
         return $xml;
     }
 
-    // Archiving API Requests
-
-    public function startArchive($sessionId, $options)
+    public function startArchive(string $sessionId, array $options = []): array
     {
-        // set up the request
         $request = new Request('POST', '/v2/project/' . $this->apiKey . '/archive');
 
         try {
             $response = $this->client->send($request, [
                 'debug' => $this->isDebug(),
                 'json' => array_merge(
-                    array( 'sessionId' => $sessionId ),
+                    ['sessionId' => $sessionId],
                     $options
                 )
             ]);
@@ -283,7 +281,7 @@ class Client
         return $archiveListJson;
     }
 
-    public function startBroadcast($sessionId, $options)
+    public function startBroadcast(string $sessionId, array $options): array
     {
         $request = new Request(
             'POST',
@@ -362,40 +360,36 @@ class Client
         return $layoutJson;
     }
 
-    public function updateLayout($resourceId, $layout, $resourceType = 'broadcast')
+    public function updateLayout(string $resourceId, Layout $layout, string $resourceType = 'broadcast'): void
     {
         $request = new Request(
             'PUT',
             '/v2/project/' . $this->apiKey . '/' . $resourceType . '/' . $resourceId . '/layout'
         );
         try {
-            $response = $this->client->send($request, [
+            $this->client->send($request, [
                 'debug' => $this->isDebug(),
-                'json' => $layout->jsonSerialize()
+                'json' => $layout->toArray()
             ]);
-            $layoutJson = json_decode($response->getBody(), true);
         } catch (\Exception $e) {
             $this->handleException($e);
         }
-        return $layoutJson;
     }
 
-    public function setArchiveLayout($archiveId, $layout)
+    public function setArchiveLayout(string $archiveId, Layout $layout): void
     {
         $request = new Request(
             'PUT',
             '/v2/project/' . $this->apiKey . '/archive/' . $archiveId . '/layout'
         );
         try {
-            $response = $this->client->send($request, [
+            $this->client->send($request, [
                 'debug' => $this->isDebug(),
-                'json' => $layout->jsonSerialize()
+                'json' => $layout->toArray()
             ]);
-            $layoutJson = json_decode($response->getBody(), true);
         } catch (\Exception $e) {
             $this->handleException($e);
         }
-        return $layoutJson;
     }
 
     public function updateStream($sessionId, $streamId, $properties)

--- a/tests/OpenTokTest/LayoutTest.php
+++ b/tests/OpenTokTest/LayoutTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace OpenTokTest;
+
+use OpenTok\Layout;
+use PHPStan\Testing\TestCase;
+
+class LayoutTest extends TestCase
+{
+    public function testStylesheetIsNotInSerializedArrayIfNotCustom()
+    {
+        $layouts = [
+            Layout::LAYOUT_BESTFIT => Layout::getBestFit(),
+            Layout::LAYOUT_HORIZONTAL => Layout::getHorizontalPresentation(),
+            Layout::LAYOUT_PIP => Layout::getPIP(),
+            Layout::LAYOUT_VERTICAL => Layout::getVerticalPresentation(),
+        ];
+
+        foreach ($layouts as $type => $object) {
+            $this->assertSame(['type' => $type], $object->toArray());
+        }
+    }
+
+    public function testStylesheetIsInSerializedArrayIfCustom()
+    {
+        $layout = Layout::createCustom(['stylesheet' => 'foo']);
+
+        $this->assertSame(['type' => LAYOUT::LAYOUT_CUSTOM, 'stylesheet' => 'foo'], $layout->toArray());
+    }
+
+    public function testScreenshareTypeSerializesProperly()
+    {
+        $layout = Layout::getBestFit();
+        $layout->setScreenshareType(Layout::LAYOUT_PIP);
+
+        $expected = [
+            'type' => 'bestFit',
+            'screenshareType' => 'pip'
+        ];
+
+        $this->assertSame($expected, $layout->toArray());
+    }
+
+    public function testScreenshareTypeCannotBeSetToInvalidValue()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Screenshare type must be of a valid layout type');
+
+        $layout = Layout::getBestFit();
+        $layout->setScreenshareType('bar');
+    }
+
+    public function testScreenshareTypeCannotBeSetOnInvalidLayoutType()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Screenshare type cannot be set on a layout type other than bestFit');
+
+        $layout = Layout::createCustom(['stylesheet' => 'foo']);
+        $layout->setScreenshareType(Layout::LAYOUT_PIP);
+    }
+}

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -578,7 +578,10 @@ class OpenTokTest extends TestCase
         // TODO: test the properties of the actual archive object
     }
 
-    // this is the deprecated method signature, remove in v3.0.0 (and not before)
+    /**
+     * this is the deprecated method signature, remove in v3.0.0 (and not before)
+     * @todo Remove this when `startArchive` removes string support
+     */
     public function testStartsArchiveNamedDeprecated()
     {
         // Arrange
@@ -595,7 +598,7 @@ class OpenTokTest extends TestCase
         $sessionId = '2_MX44NTQ1MTF-flR1ZSBOb3YgMTIgMDk6NDA6NTkgUFNUIDIwMTN-MC43NjU0Nzh-';
 
         // Act
-        $archive = $this->opentok->startArchive($sessionId, 'showtime');
+        @$archive = $this->opentok->startArchive($sessionId, 'showtime');
 
         // Assert
         $this->assertCount(1, $this->historyContainer);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds the `screenshareType` key to the `\Opentok\Layout` class to support screenshare layouts. Users can now set a type on the layout objects directly with `setScreenshareType`.

This also includes cleanup around the methods that use the Layout features, as well as static typing for those methods.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `screenshareType` option for layouts was added to the API, so this allows that functionality through the SDKs.

The other cleanups are general quality-of-life cleanups that are done on legacy code as we do maintenance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Example Output or Screenshots (if appropriate):

```php
$layout = Layout::getBestFit();
$layout->setScreenshareLayout(Layout::LAYOUT_VERTICAL);
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
