### PR TITLE
Carry forward observeForceMute into the client

### DIFF
--- a/src/OpenTok/Util/Client.php
+++ b/src/OpenTok/Util/Client.php
@@ -628,7 +628,8 @@ class Client
             'token' => $token,
             'sip' => array(
                 'uri' => $sipUri,
-                'secure' => $options['secure']
+                'secure' => $options['secure'],
+                'observeForceMute' => $options['observeForceMute']
             )
         );
 


### PR DESCRIPTION
This fixes a bug where the OpenTok client observeForceMute parameter was not carrying forward to the API Client class.

## Description
Added observeForceMute into the API client options payload.

## Motivation and Context
Bug fix

## How Has This Been Tested?
Test suite passes

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
