### PR TITLE
observeForceMute attribute is not returned by the /call endpoint

### DIFF
--- a/src/OpenTok/SipCall.php
+++ b/src/OpenTok/SipCall.php
@@ -32,7 +32,6 @@ class SipCall
         $this->data['id'] = $sipCallData['id'];
         $this->data['connectionId'] = $sipCallData['connectionId'];
         $this->data['streamId'] = $sipCallData['streamId'];
-        $this->data['observeForceMute'] = $sipCallData['observeForceMute'];
     }
 
     /**
@@ -45,7 +44,6 @@ class SipCall
             case 'id':
             case 'connectionId':
             case 'streamId':
-            case 'observeForceMute':
                 return $this->data[$name];
             default:
                 return null;

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -2077,7 +2077,6 @@ class OpenTokTest extends TestCase
         $this->assertNotNull($sipCall->id);
         $this->assertNotNull($sipCall->connectionId);
         $this->assertNotNull($sipCall->streamId);
-        $this->assertEquals(false, $sipCall->observeForceMute);
 
         $this->assertCount(1, $this->historyContainer);
         $request = $this->historyContainer[0]['request'];
@@ -2111,7 +2110,6 @@ class OpenTokTest extends TestCase
         $this->assertNotNull($sipCall->id);
         $this->assertNotNull($sipCall->connectionId);
         $this->assertNotNull($sipCall->streamId);
-        $this->assertEquals(true, $sipCall->observeForceMute);
 
         $this->assertCount(1, $this->historyContainer);
         $request = $this->historyContainer[0]['request'];

--- a/tests/mock/v2/project/APIKEY/dial
+++ b/tests/mock/v2/project/APIKEY/dial
@@ -1,5 +1,5 @@
 {
   "id" : "1bae377f-d620-4e58-86c0-5a37364eec0c",
   "connectionId" : "da9cb410-e29b-4c2d-ab9e-fe65bf83fcaf",
-  "streamId" : "e6f13213-22cb-45de-b71d-af7cef329954",
+  "streamId" : "e6f13213-22cb-45de-b71d-af7cef329954"
 }

--- a/tests/mock/v2/project/APIKEY/dial
+++ b/tests/mock/v2/project/APIKEY/dial
@@ -2,5 +2,4 @@
   "id" : "1bae377f-d620-4e58-86c0-5a37364eec0c",
   "connectionId" : "da9cb410-e29b-4c2d-ab9e-fe65bf83fcaf",
   "streamId" : "e6f13213-22cb-45de-b71d-af7cef329954",
-  "observeForceMute" : false
 }

--- a/tests/mock/v2/project/APIKEY/dialForceMute
+++ b/tests/mock/v2/project/APIKEY/dialForceMute
@@ -1,5 +1,5 @@
 {
   "id" : "1bae377f-d620-4e58-86c0-5a37364eec0c",
   "connectionId" : "da9cb410-e29b-4c2d-ab9e-fe65bf83fcaf",
-  "streamId" : "e6f13213-22cb-45de-b71d-af7cef329954",
+  "streamId" : "e6f13213-22cb-45de-b71d-af7cef329954"
 }

--- a/tests/mock/v2/project/APIKEY/dialForceMute
+++ b/tests/mock/v2/project/APIKEY/dialForceMute
@@ -2,5 +2,4 @@
   "id" : "1bae377f-d620-4e58-86c0-5a37364eec0c",
   "connectionId" : "da9cb410-e29b-4c2d-ab9e-fe65bf83fcaf",
   "streamId" : "e6f13213-22cb-45de-b71d-af7cef329954",
-  "observeForceMute" : true
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The /call endpoint don't return anything about the observeForceMute parameter, eg of response:

array (
  'id' => '',
  'projectId' => '',
  'sessionId' => '',
  'connectionId' => '',
  'streamId' => '',
  'createdAt' => 1656512547785,
  'updatedAt' => 1656512547785,
)  

I also tried the /dial endpoint (the right one according to your documentation: https://tokbox.com/developer/rest/#sip_call) but the result is the same. But maybe the issue is on your API that don't expose this attribute yet.

## Motivation and Context
We can't use the latest version of your SDK right now.

## How Has This Been Tested?

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
