### PR TITLE
Add Audio Connector for the ability to add audio to Websockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The OpenTok PHP SDK provides methods for:
 * [Sending signals to clients connected to a session](https://tokbox.com/developer/guides/signaling/)
 * [Disconnecting clients from sessions](https://tokbox.com/developer/guides/moderation/rest/)
 * [Forcing clients in a session to disconnect or mute published audio](https://tokbox.com/developer/guides/moderation/)
+* Working with OpenTok [Audio Connector](https://tokbox.com/developer/guides/audio-connector)
 
 ## Installation
 
@@ -473,6 +474,12 @@ $opentok->dial($sessionId, $token, $sipUri, $options);
 
 For more information, see the [OpenTok SIP Interconnect developer
 guide](https://tokbox.com/developer/guides/sip/).
+
+### Working with Audio Connector
+
+You can start an [Audio Connector](https://tokbox.com/developer/guides/audio-connector) WebSocket
+by calling the `connectAudio()` method of the
+`OpenTok\OpenTok` class.
 
 ## Samples
 

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -1047,7 +1047,12 @@ class OpenTok
      *    <li><code>'headers'</code> (array) &mdash; (Optional) An object of key/val pairs with additional properties to send to your Websocket server, with a maximum length of 512 bytes.</li>
      * </ul>
      *
-     * @return array $response Response from the API.
+     * @return array $response Response from the API, structured as follows:
+     * <ul>
+     *    <li><code>'id'</code> (string) &mdash; Identifier of the outgoing WebSocket connect call that can be used for debugging purposes</li>
+     *    <li><code>'connectionId'</code> (string) &mdash; Opentok client connectionId that has been created. This connection will subscribe and forward the streams defined in the payload to the WebSocket, as any other participant, will produce a connectionCreated event on the session.</li>
+     * </ul>
+     *
      *
      */
     public function connectAudioStream(string $sessionId, string $token, array $websocketOptions)

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -1031,6 +1031,33 @@ class OpenTok
         }
     }
 
+    /**
+     * Send audio from a Vonage Video API session to a WebSocket.
+     *
+     * @param string $sessionId The session ID.
+     *
+     * @param string $token The OpenTok token to be used for the Audio Streamer connection to the
+     * OpenTok session. You can add token data to identify that the connection
+     * is the Audio Streamer endpoint or for other identifying data.
+     *
+     * @param array $websocketOptions Configuration for the Websocket. Contains the following keys:
+     * <ul>
+     *    <li><code>'uri'</code> (string) &mdash; A publically reachable WebSocket URI controlled by the customer for the destination of the connect call. (f.e. wss://service.com/wsendpoint)</li>
+     *    <li><code>'streams'</code> (array) &mdash; (Optional) The stream IDs of the participants' whose audio is going to be connected. If not provided, all streams in session will be selected.</li>
+     *    <li><code>'headers'</code> (array) &mdash; (Optional) An object of key/val pairs with additional properties to send to your Websocket server, with a maximum length of 512 bytes.</li>
+     * </ul>
+     *
+     * @return array $response Response from the API.
+     *
+     */
+    public function connectAudioStream(string $sessionId, string $token, array $websocketOptions)
+    {
+        Validators::validateStreamId($sessionId);
+        Validators::validateWebsocketOptions($websocketOptions);
+
+        return $this->client->connectAudioStream($sessionId, $token, $websocketOptions);
+    }
+
     /** @internal */
     private function signString($string, $secret)
     {

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -1050,14 +1050,14 @@ class OpenTok
     }
 
     /**
-     * Starts an <a href="https://tokbox.com/developer/guides/audio-streamer/">Audio Streamer</a>
+     * Starts an <a href="https://tokbox.com/developer/guides/audio-connector/">Audio Connector</a>
      * WebSocket connection. to send audio from a Vonage Video API session to a WebSocket.
      *
      * @param string $sessionId The session ID.
      *
-     * @param string $token The OpenTok token to be used for the Audio Streamer connection to the
+     * @param string $token The OpenTok token to be used for the Audio Connector to the
      * OpenTok session. You can add token data to identify that the connection
-     * is the Audio Streamer endpoint or for other identifying data.
+     * is the Audio Connector endpoint or for other identifying data.
      *
      * @param array $websocketOptions Configuration for the Websocket. Contains the following keys:
      * <ul>
@@ -1068,19 +1068,19 @@ class OpenTok
      *
      * @return array $response Response from the API, structured as follows:
      * <ul>
-     *    <li><code>'id'</code> (string) &mdash; A unique ID identifying the Audio Streamer
-     *    WebSocket connection.</li>
+     *    <li><code>'id'</code> (string) &mdash; A unique ID identifying the Audio Connector
+     *    WebSocket.</li>
      *    <li><code>'connectionId'</code> (string) &mdash; Opentok client connectionId that has been created. This connection will subscribe and forward the streams defined in the payload to the WebSocket, as any other participant, will produce a connectionCreated event on the session.</li>
      * </ul>
      *
      *
      */
-    public function connectAudioStream(string $sessionId, string $token, array $websocketOptions)
+    public function connectAudio(string $sessionId, string $token, array $websocketOptions)
     {
         Validators::validateSessionId($sessionId);
         Validators::validateWebsocketOptions($websocketOptions);
 
-        return $this->client->connectAudioStream($sessionId, $token, $websocketOptions);
+        return $this->client->connectAudio($sessionId, $token, $websocketOptions);
     }
 
     /** @internal */

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -1050,7 +1050,8 @@ class OpenTok
      *
      * @return array $response Response from the API, structured as follows:
      * <ul>
-     *    <li><code>'id'</code> (string) &mdash; Identifier of the outgoing WebSocket connect call that can be used for debugging purposes</li>
+     *    <li><code>'id'</code> (string) &mdash; A unique ID identifying the Audio Streamer
+     *    WebSocket connection.</li>
      *    <li><code>'connectionId'</code> (string) &mdash; Opentok client connectionId that has been created. This connection will subscribe and forward the streams defined in the payload to the WebSocket, as any other participant, will produce a connectionCreated event on the session.</li>
      * </ul>
      *

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -1052,7 +1052,7 @@ class OpenTok
      */
     public function connectAudioStream(string $sessionId, string $token, array $websocketOptions)
     {
-        Validators::validateStreamId($sessionId);
+        Validators::validateSessionId($sessionId);
         Validators::validateWebsocketOptions($websocketOptions);
 
         return $this->client->connectAudioStream($sessionId, $token, $websocketOptions);

--- a/src/OpenTok/Util/Client.php
+++ b/src/OpenTok/Util/Client.php
@@ -3,7 +3,6 @@
 namespace OpenTok\Util;
 
 use Exception as GlobalException;
-use http\Exception\InvalidArgumentException;
 use OpenTok\Layout;
 use Firebase\JWT\JWT;
 use OpenTok\MediaMode;

--- a/src/OpenTok/Util/Client.php
+++ b/src/OpenTok/Util/Client.php
@@ -781,11 +781,31 @@ class Client
         return $jsonResponse;
     }
 
-    //echo 'Uh oh! ' . $e->getMessage();
-    //echo 'HTTP request URL: ' . $e->getRequest()->getUrl() . "\n";
-    //echo 'HTTP request: ' . $e->getRequest() . "\n";
-    //echo 'HTTP response status: ' . $e->getResponse()->getStatusCode() . "\n";
-    //echo 'HTTP response: ' . $e->getResponse() . "\n";
+    public function connectAudioStream(string $sessionId, string $token, array $websocketOptions)
+    {
+        $request = new Request(
+            'POST',
+            '/v2/project/' . $this->apiKey . '/connect'
+        );
+
+        $body = [
+            'sessionId' => $sessionId,
+            'token' => $token,
+            'websocket' => $websocketOptions
+        ];
+
+        try {
+            $response = $this->client->send($request, [
+                'debug' => $this->isDebug(),
+                'json' => $body
+            ]);
+            $jsonResponse = json_decode($response->getBody(), true);
+        } catch (\Exception $e) {
+            $this->handleException($e);
+            return false;
+        }
+        return $jsonResponse;
+    }
 
     private function handleException($e)
     {

--- a/src/OpenTok/Util/Client.php
+++ b/src/OpenTok/Util/Client.php
@@ -106,7 +106,7 @@ class Client
             'iss' => $this->apiKey,
             'iat' => time(), // this is in seconds
             'exp' => time() + (5 * 60),
-            'jti' => uniqid(),
+            'jti' => uniqid('', true),
         );
         return JWT::encode($token, $this->apiSecret);
     }
@@ -781,7 +781,7 @@ class Client
         return $jsonResponse;
     }
 
-    public function connectAudioStream(string $sessionId, string $token, array $websocketOptions)
+    public function connectAudio(string $sessionId, string $token, array $websocketOptions)
     {
         $request = new Request(
             'POST',

--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -349,7 +349,7 @@ class Validators
     }
     public static function validateStreamId($streamId)
     {
-        if (!(is_string($streamId))) {
+        if (!(is_string($streamId)) || empty($streamId)) {
             throw new InvalidArgumentException('The streamId was not a string: ' . print_r($streamId, true));
         }
     }

--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -61,6 +61,7 @@ class Validators
             throw new InvalidArgumentException('The apiSecret was not a string: ' . print_r($apiSecret, true));
         }
     }
+
     public static function validateApiUrl($apiUrl)
     {
         if (!(is_string($apiUrl) && filter_var($apiUrl, FILTER_VALIDATE_URL))) {
@@ -69,6 +70,7 @@ class Validators
             );
         }
     }
+
     public static function validateClient($client)
     {
         if (isset($client) && !($client instanceof Client)) {

--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -362,6 +362,13 @@ class Validators
         }
     }
 
+    public static function validateWebsocketOptions(array $websocketOptions)
+    {
+        if (!array_key_exists('uri', $websocketOptions)) {
+            throw new InvalidArgumentException('Websocket configuration must have a uri');
+        }
+    }
+
     public static function validateLayoutClassListItem($layoutClassList)
     {
         if (!is_string($layoutClassList['id'])) {

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -1237,7 +1237,7 @@ class OpenTokTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectErrorMessage('Null or empty session ID is not valid: ');
-        $this->opentok->connectAudioStream('', '2398523', []);
+        $this->opentok->connectAudio('', '2398523', []);
     }
 
     public function testCannotConnectAudioStreamWithoutWebsocketUri()
@@ -1253,7 +1253,7 @@ class OpenTokTest extends TestCase
             'headers' => ['key' => 'value']
         ];
 
-        $this->opentok->connectAudioStream('9999', 'wrwetg', $badPayload);
+        $this->opentok->connectAudio('9999', 'wrwetg', $badPayload);
     }
 
     public function testCanConnectAudioStreamWithWebsocket()
@@ -1279,7 +1279,7 @@ class OpenTokTest extends TestCase
             ]
         ];
 
-        $response = $this->opentok->connectAudioStream($sessionId, $token, $websocketConfig);
+        $response = $this->opentok->connectAudio($sessionId, $token, $websocketConfig);
         $this->assertEquals('063e72a4-64b4-43c8-9da5-eca071daab89', $response['id']);
         $this->assertEquals('7aebb3a4-3d86-4962-b317-afb73e05439d', $response['connectionId']);
     }

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -1229,6 +1229,61 @@ class OpenTokTest extends TestCase
         $this->opentok->forceDisconnect($sessionId, $connectionId);
     }
 
+    public function testCannotConnectAudioStreamWithInvalidSessionId()
+    {
+        $this->setupOTWithMocks([[
+            'code' => 200
+        ]]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage('Null or empty session ID is not valid: ');
+        $this->opentok->connectAudioStream('', '2398523', []);
+    }
+
+    public function testCannotConnectAudioStreamWithoutWebsocketUri()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage('Websocket configuration must have a uri');
+        $this->setupOTWithMocks([[
+            'code' => 200
+        ]]);
+
+        $badPayload = [
+            'streams' => ['333425', 'asfasrst'],
+            'headers' => ['key' => 'value']
+        ];
+
+        $this->opentok->connectAudioStream('9999', 'wrwetg', $badPayload);
+    }
+
+    public function testCanConnectAudioStreamWithWebsocket()
+    {
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'path' => '/v2/project/APIKEY/connect'
+        ]]);
+
+        $sessionId = '1_MX4xMjM0NTY3OH4-VGh1IEZlYiAyNyAwNDozODozMSBQU1QgMjAxNH4wLjI0NDgyMjI';
+        $token = '063e72a4-64b4-43c8-9da5-eca071daab89';
+        $websocketConfig = [
+            'uri' => 'ws://service.com/wsendpoint',
+            'streams' => [
+                'we9r885',
+                '9238fujs'
+            ],
+            'headers' => [
+                'key1' => 'value'
+            ]
+        ];
+
+        $response = $this->opentok->connectAudioStream($sessionId, $token, $websocketConfig);
+        $this->assertEquals('063e72a4-64b4-43c8-9da5-eca071daab89', $response['id']);
+        $this->assertEquals('7aebb3a4-3d86-4962-b317-afb73e05439d', $response['connectionId']);
+    }
+
 	public function testCanStartBroadcastWithRmtp()
 	{
 		$this->setupOTWithMocks([[

--- a/tests/OpenTokTest/Util/ClientTest.php
+++ b/tests/OpenTokTest/Util/ClientTest.php
@@ -29,7 +29,7 @@ class ClientTest extends TestCase
             'uri' => 'ws://test'
         ];
 
-        $response = $client->connectAudioStream('ddd', 'sarar55r', $websocketDummy);
+        $response = $client->connectAudio('ddd', 'sarar55r', $websocketDummy);
         $this->assertEquals('063e72a4-64b4-43c8-9da5-eca071daab89', $response['id']);
         $this->assertEquals('7aebb3a4-3d86-4962-b317-afb73e05439d', $response['connectionId']);
     }

--- a/tests/OpenTokTest/Util/ClientTest.php
+++ b/tests/OpenTokTest/Util/ClientTest.php
@@ -3,36 +3,35 @@
 namespace OpenTokTest\Util;
 
 use GuzzleHttp\Client as GuzzleHttpClient;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use OpenTok\Exception\SignalAuthenticationException;
 use OpenTok\Exception\SignalConnectionException;
-use OpenTok\Exception\SignalNetworkConnectionException;
 use OpenTok\Exception\SignalUnexpectedValueException;
 use OpenTok\Util\Client;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Psr\Http\Message\RequestInterface;
 
 class ClientTest extends TestCase
 {
-    public function testHandlesSignalErrorHandlesNoResponse()
+    public function testCanAddAudioStreamToWebsocket()
     {
-        $this->expectException(SignalNetworkConnectionException::class);
-        $this->expectExceptionMessage('Unable to communicate with host');
-
         $mock = new MockHandler([
-            new RequestException('Unable to communicate with host', new Request('GET', 'signals')),
+            $this->getResponse('connect')
         ]);
         $handlerStack = HandlerStack::create($mock);
         $guzzle = new GuzzleHttpClient(['handler' => $handlerStack]);
 
         $client = new Client();
         $client->configure('asdf', 'asdf', 'http://localhost/', ['client' => $guzzle]);
-        $client->signal('sessionabcd', ['type' => 'foo', 'data' => 'bar'], 'connection1234');
+
+        $websocketDummy = [
+            'uri' => 'ws://test'
+        ];
+
+        $response = $client->connectAudioStream('ddd', 'sarar55r', $websocketDummy);
+        $this->assertEquals('063e72a4-64b4-43c8-9da5-eca071daab89', $response['id']);
+        $this->assertEquals('7aebb3a4-3d86-4962-b317-afb73e05439d', $response['connectionId']);
     }
 
     public function testHandlesSignalErrorHandles400Response()

--- a/tests/OpenTokTest/Util/responses/connect.json
+++ b/tests/OpenTokTest/Util/responses/connect.json
@@ -1,0 +1,4 @@
+{
+  "id": "063e72a4-64b4-43c8-9da5-eca071daab89",
+  "connectionId": "7aebb3a4-3d86-4962-b317-afb73e05439d"
+}

--- a/tests/OpenTokTest/Validators/ValidatorsTest.php
+++ b/tests/OpenTokTest/Validators/ValidatorsTest.php
@@ -8,7 +8,56 @@ use PHPUnit\Framework\TestCase;
 
 class ValidatorsTest extends TestCase
 {
-    public function testWillPassCorrectPayload(): void
+    public function testWillValidateStringApiKey(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $apiKey = '47347801';
+        Validators::validateApiKey($apiKey);
+    }
+
+    public function testWillValidateIntegerApiKey(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $apiKey = 47347801;
+        Validators::validateApiKey($apiKey);
+    }
+
+    public function testWillInvalidateApiKey(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $apiKey = [47347801];
+        Validators::validateApiKey($apiKey);
+    }
+
+    public function testWillValidateApiSecret(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $secret = 'cdff574f0b071230be098e279d16931116c43fcf';
+        Validators::validateApiSecret($secret);
+    }
+
+    public function testWillInvalidateApiSecret(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $secret = 3252556;
+        Validators::validateApiSecret($secret);
+    }
+
+    public function testWillValidateApiUrl(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $apiUrl = 'https://api.opentok.com';
+        Validators::validateApiUrl($apiUrl);
+    }
+
+    public function testWillInvalidateApiUrl(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $apiUrl = 'dave@opentok.com';
+        Validators::validateApiUrl($apiUrl);
+    }
+
+    public function testWillPassCorrectForceMutePayload(): void
     {
         $this->expectNotToPerformAssertions();
 
@@ -67,6 +116,7 @@ class ValidatorsTest extends TestCase
 
     public function testWillValidateWebsocketConfiguration(): void
     {
+        $this->expectNotToPerformAssertions();
         $websocketConfig = [
             'uri' => 'ws://valid-websocket',
             'streams' => [
@@ -75,8 +125,6 @@ class ValidatorsTest extends TestCase
             ]
         ];
         Validators::validateWebsocketOptions($websocketConfig);
-        // This smells awful but the way validators have been structured mean it's a necessary evil
-        $this->assertTrue(true);
     }
 
     public function testWillThrowExceptionOnInvalidWebsocketConfiguration(): void

--- a/tests/OpenTokTest/Validators/ValidatorsTest.php
+++ b/tests/OpenTokTest/Validators/ValidatorsTest.php
@@ -64,4 +64,31 @@ class ValidatorsTest extends TestCase
 
         Validators::validateForceMuteAllOptions($options);
     }
+
+    public function testWillValidateWebsocketConfiguration(): void
+    {
+        $websocketConfig = [
+            'uri' => 'ws://valid-websocket',
+            'streams' => [
+                '525503c7-913e-43a1-84b4-31b2e9fe668b',
+                '14026813-4f50-4a5a-9b72-fea25430916d'
+            ]
+        ];
+        Validators::validateWebsocketOptions($websocketConfig);
+        // This smells awful but the way validators have been structured mean it's a necessary evil
+        $this->assertTrue(true);
+    }
+
+    public function testWillThrowExceptionOnInvalidWebsocketConfiguration(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $websocketConfig = [
+            'streams' => [
+                '525503c7-913e-43a1-84b4-31b2e9fe668b',
+                '14026813-4f50-4a5a-9b72-fea25430916d'
+            ]
+        ];
+        Validators::validateWebsocketOptions($websocketConfig);
+    }
 }

--- a/tests/mock/v2/project/APIKEY/connect
+++ b/tests/mock/v2/project/APIKEY/connect
@@ -1,0 +1,4 @@
+{
+  "id": "063e72a4-64b4-43c8-9da5-eca071daab89",
+  "connectionId": "7aebb3a4-3d86-4962-b317-afb73e05439d"
+}


### PR DESCRIPTION
Add Audio Connector for the ability to add audio to Websockets

## Description
This PR adds a new method to the base Client, allowing for audio streams to be added to open websockets using the Audio Connector.

## Motivation and Context
New feature as requested

## How Has This Been Tested?
Three new tests and a fixture to mock out behaviour

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
