### PR TITLE
HD Resolutions for Broadcast / Archive

### DIFF
--- a/src/OpenTok/Archive.php
+++ b/src/OpenTok/Archive.php
@@ -41,7 +41,9 @@ use OpenTok\Exception\ArchiveUnexpectedValueException;
 * the archive stopped (such as "maximum duration exceeded") or failed.
 *
 * @property string $resolution
-* The resolution of the archive.
+* The resolution of the archive, either "640x480" (SD landscape, the default), "1280x720" (HD landscape),
+* "1920x1080" (FHD landscape), "480x640" (SD portrait), "720x1280" (HD portrait), or "1080x1920" (FHD portrait).
+* You may want to use a portrait aspect ratio for archives that include video streams from mobile devices (which often use the portrait aspect ratio).
 *
 * @property string $sessionId
 * The session ID of the OpenTok session associated with this archive.

--- a/src/OpenTok/Broadcast.php
+++ b/src/OpenTok/Broadcast.php
@@ -85,7 +85,7 @@ class Broadcast
             'streamMode' => StreamMode::AUTO,
             'isHls' => true,
             'isLowLatency' => false,
-            'isDvr' => false
+            'isDvr' => false,
         );
         $options = array_merge($defaults, array_intersect_key($options, $defaults));
         list($apiKey, $apiSecret, $apiUrl, $client, $isStopped, $streamMode) = array_values($options);

--- a/src/OpenTok/Broadcast.php
+++ b/src/OpenTok/Broadcast.php
@@ -44,6 +44,11 @@ use OpenTok\Util\Validators;
 * @property boolean $isLowLatency
 * Whether the broadcast supports low-latency mode for the HLS stream.
 *
+* @property string $resolution
+* The resolution of the archive, either "640x480" (SD landscape, the default), "1280x720" (HD landscape),
+* "1920x1080" (FHD landscape), "480x640" (SD portrait), "720x1280" (HD portrait), or "1080x1920" (FHD portrait).
+* You may want to use a portrait aspect ratio for archives that include video streams from mobile devices (which often use the portrait aspect ratio).
+*
 * @property string $streamMode
 * Whether streams included in the broadcast are selected automatically (<code>StreamMode.AUTO</code>)
 * or manually (<code>StreamMode.MANUAL</code>). When streams are selected automatically (<code>StreamMode.AUTO</code>),
@@ -69,6 +74,8 @@ class Broadcast
     private $isLowLatency;
     /** @ignore */
     private $isDvr;
+    /** @ignore */
+    private $resolution;
 
     /** @ignore */
     public function __construct($broadcastData, $options = array())
@@ -98,6 +105,7 @@ class Broadcast
         $this->data = $broadcastData;
 
         $this->isStopped = $isStopped;
+        $this->resolution = $this->data['resolution'];
         $this->isHls = isset($this->data['settings']['hls']);
         $this->isLowLatency = $this->data['settings']['hls']['lowLatency'] ?? false;
         $this->isDvr = $this->data['settings']['hls']['dvr'] ?? false;
@@ -124,9 +132,10 @@ class Broadcast
             case 'broadcastUrls':
             case 'status':
             case 'maxDuration':
-            case 'resolution':
             case 'streamMode':
                 return $this->data[$name];
+            case 'resolution':
+                return $this->resolution;
             case 'hlsUrl':
                 return $this->data['broadcastUrls']['hls'];
             case 'isStopped':

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -306,6 +306,11 @@ class OpenTok
      *    archive are recorded to a single file (<code>OutputMode::COMPOSED</code>, the default)
      *    or to individual files (<code>OutputMode::INDIVIDUAL</code>).</li>
      *
+     *    <li><code>'resolution'</code> (String) &mdash; The resolution of the archive, either "640x480" (SD landscape,
+     *    the default), "1280x720" (HD landscape), "1920x1080" (FHD landscape), "480x640" (SD portrait), "720x1280"
+     *    (HD portrait), or "1080x1920" (FHD portrait). This property only applies to composed archives. If you set
+     *    this property and set the outputMode property to "individual", a call to the method
+     *    results in an error.</li>
      * </ul>
      *
      * @return Archive The Archive object, which includes properties defining the archive, including
@@ -329,13 +334,18 @@ class OpenTok
             'hasAudio' => true,
             'outputMode' => OutputMode::COMPOSED,
             'resolution' => null,
-            'streamMode' => StreamMode::AUTO
+            'streamMode' => StreamMode::AUTO,
         );
         $options = array_merge($defaults, array_intersect_key($options, $defaults));
         list($name, $hasVideo, $hasAudio, $outputMode, $resolution, $streamMode) = array_values($options);
-        // validate arguments
+
         Validators::validateSessionId($sessionId);
         Validators::validateArchiveName($name);
+
+        if ($resolution) {
+            Validators::validateResolution($resolution);
+        }
+
         Validators::validateArchiveHasVideo($hasVideo);
         Validators::validateArchiveHasAudio($hasAudio);
         Validators::validateArchiveOutputMode($outputMode);
@@ -352,8 +362,7 @@ class OpenTok
             $errorMessage = "Resolution must be a valid string";
             throw new UnexpectedValueException($errorMessage);
         }
-        // we don't validate the actual resolution so if we add resolutions, we don't artificially block functionality
-        // make API call
+
         $archiveData = $this->client->startArchive($sessionId, $options);
 
         return new Archive($archiveData, array( 'client' => $this->client ));
@@ -637,6 +646,10 @@ class OpenTok
      *    <a href="https://tokbox.com/developer/guides/archive-broadcast-layout/#stream-prioritization-rules">stream
      *    prioritization rules</a>.</li>
      *
+     *    <li><code>resolution</code> &mdash; The resolution of the broadcast: either "640x480" (SD landscape, the default), "1280x720" (HD landscape),
+     *    "1920x1080" (FHD landscape), "480x640" (SD portrait), "720x1280" (HD portrait), or "1080x1920"
+     *    (FHD portrait).</li>
+     *
      *    <li><code>outputs</code> (Array) &mdash;
      *      Defines the HLS broadcast and RTMP streams. You can provide the following keys:
      *      <ul>
@@ -678,6 +691,10 @@ class OpenTok
         // not preferred to depend on that in the SDK because its then harder to garauntee backwards
         // compatibility
 
+        if (isset($options['resolution'])) {
+            Validators::validateResolution($options['resolution']);
+        }
+
 	    if (isset($options['output']['hls'])) {
 		    Validators::validateBroadcastOutputOptions($options['output']['hls']);
 	    }
@@ -689,6 +706,7 @@ class OpenTok
         $defaults = [
             'layout' => Layout::getBestFit(),
             'streamMode' => 'auto',
+            'resolution' => '640x480',
 	        'output' => [
 				'hls' => [
 	                'dvr' => false,
@@ -709,7 +727,7 @@ class OpenTok
         // make API call
         $broadcastData = $this->client->startBroadcast($sessionId, $options);
 
-        return new Broadcast($broadcastData, array( 'client' => $this->client ));
+        return new Broadcast($broadcastData, array('client' => $this->client));
     }
 
     /**

--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -341,18 +341,41 @@ class Validators
             );
         }
     }
+
     public static function validateLayoutStylesheet($stylesheet)
     {
         if (!(is_string($stylesheet))) {
             throw new InvalidArgumentException('The stylesheet was not a string: ' . print_r($stylesheet, true));
         }
     }
+
+    public static function validateResolution($resolution)
+    {
+        if (!(is_string($resolution))) {
+            throw new InvalidArgumentException('The resolution was not a string: ' . print_r($resolution, true));
+        }
+
+        $validResolutions = [
+            '640x480',
+            '1280x720',
+            '1920x1080',
+            '480x640',
+            '720x1280',
+            '1080x1920',
+        ];
+
+        if (!in_array(strtolower($resolution), $validResolutions)) {
+            throw new InvalidArgumentException('The resolution was not a valid resolution: ' . print_r($resolution, true));
+        }
+    }
+
     public static function validateStreamId($streamId)
     {
         if (!(is_string($streamId))) {
             throw new InvalidArgumentException('The streamId was not a string: ' . print_r($streamId, true));
         }
     }
+
     public static function validateLayoutClassList($layoutClassList, $format = 'JSON')
     {
         if ($format === 'JSON') {

--- a/tests/OpenTokTest/Validators/ValidatorsTest.php
+++ b/tests/OpenTokTest/Validators/ValidatorsTest.php
@@ -64,4 +64,33 @@ class ValidatorsTest extends TestCase
 
         Validators::validateForceMuteAllOptions($options);
     }
+
+
+    /**
+     * @dataProvider resolutionProvider
+     */
+    public function testValidResolutions($resolution, $isValid): void
+    {
+        if (!$isValid) {
+            $this->expectException(InvalidArgumentException::class);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        Validators::validateResolution($resolution);
+    }
+
+    public function resolutionProvider(): array
+    {
+        return [
+            ['640x480', true],
+            ['1280x720', true],
+            ['1920x1080', true],
+            ['480x640', true],
+            ['720x1280', true],
+            ['1080x1920', true],
+            ['1080X1920', true],
+            ['923x245', false]
+        ];
+    }
 }

--- a/tests/mock/v2/project/APIKEY/broadcast/BROADCASTID/get
+++ b/tests/mock/v2/project/APIKEY/broadcast/BROADCASTID/get
@@ -5,6 +5,7 @@
   "createdAt":1472435660275,
   "broadcastUrls":null,
   "updatedAt":1472435660275,
+  "resolution": "640x480",
   "status":"stopped",
   "partnerId":854511
 }

--- a/tests/mock/v2/project/APIKEY/broadcast/BROADCASTID/stop
+++ b/tests/mock/v2/project/APIKEY/broadcast/BROADCASTID/stop
@@ -5,6 +5,7 @@
   "createdAt":1472435660275,
   "broadcastUrls":null,
   "updatedAt":1472435660275,
+  "resolution": "640x480",
   "status":"stopped",
   "partnerId":854511
 }


### PR DESCRIPTION
## Description
The Archive and Broadcast API endpoints now support HD resolutions. This PR adds documentation to support these options and a new validator to throw exceptions when unsupported resolutions are given as arguments before they hit the API.

## How Has This Been Tested?
New tests added for the validation

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
