### PR TITLE
Feature/multiple archive support

### DIFF
--- a/src/OpenTok/Archive.php
+++ b/src/OpenTok/Archive.php
@@ -46,6 +46,10 @@ use OpenTok\Exception\ArchiveUnexpectedValueException;
 * @property string $sessionId
 * The session ID of the OpenTok session associated with this archive.
 *
+* @property string $multiArchiveTag
+* Whether Multiple Archive is switched on, which will be a unique string for each simultaneous archive of an ongoing session.
+* See https://tokbox.com/developer/guides/archiving/#simultaneous-archives for more information.
+*
 * @property string $size
 * The size of the MP4 file. For archives that have not been generated, this value is set to 0.
 *
@@ -97,6 +101,9 @@ class Archive
     private $isDeleted;
     /** @internal */
     private $client;
+    /** @internal */
+    private $multiArchiveTag;
+
 
     /** @internal */
     public function __construct($archiveData, $options = array())
@@ -118,6 +125,9 @@ class Archive
         Validators::validateHasStreamMode($streamMode);
 
         $this->data = $archiveData;
+        if (isset($this->data['multiArchiveTag'])) {
+            $this->multiArchiveTag = $this->data['multiArchiveTag'];
+        }
 
         $this->client = isset($client) ? $client : new Client();
         if (!$this->client->isConfigured()) {
@@ -152,6 +162,8 @@ class Archive
             case 'resolution':
             case 'streamMode':
                 return $this->data[$name];
+            case 'multiArchiveTag':
+                return $this->multiArchiveTag;
             default:
                 return null;
         }

--- a/src/OpenTok/Broadcast.php
+++ b/src/OpenTok/Broadcast.php
@@ -35,8 +35,8 @@ use OpenTok\Util\Validators;
 * @property boolean $isStopped
 * Whether the broadcast is stopped (true) or in progress (false).
 *
-* @property string $multiArchiveTag
-* Whether Multiple Archive is switched on, which will be a unique string for each simultaneous broadcast of an ongoing session.
+* @property string $multiBroadcastTag
+* Whether Multiple Broadcast is switched on, which will be a unique string for each simultaneous broadcast of an ongoing session.
 * See https://tokbox.com/developer/guides/archiving/#simultaneous-archives for more information.
 *
 * @property boolean $isHls
@@ -74,7 +74,7 @@ class Broadcast
     /** @ignore */
     private $isDvr;
     /** @ignore */
-    private $multiArchiveTag;
+    private $multiBroadcastTag;
 
     /** @ignore */
     public function __construct($broadcastData, $options = array())
@@ -103,8 +103,8 @@ class Broadcast
 
         $this->data = $broadcastData;
 
-        if (isset($this->data['multiArchiveTag'])) {
-            $this->multiArchiveTag = $this->data['multiArchiveTag'];
+        if (isset($this->data['multiBroadcastTag'])) {
+            $this->multiBroadcastTag = $this->data['multiBroadcastTag'];
         }
 
         $this->isStopped = $isStopped;
@@ -147,8 +147,8 @@ class Broadcast
                 return $this->isLowLatency;
             case 'isDvr':
                 return $this->isDvr;
-            case 'multiArchiveTag':
-                return $this->multiArchiveTag;
+            case 'multiBroadcastTag':
+                return $this->multiBroadcastTag;
             default:
                 return null;
         }

--- a/src/OpenTok/Broadcast.php
+++ b/src/OpenTok/Broadcast.php
@@ -35,6 +35,10 @@ use OpenTok\Util\Validators;
 * @property boolean $isStopped
 * Whether the broadcast is stopped (true) or in progress (false).
 *
+* @property string $multiArchiveTag
+* Whether Multiple Archive is switched on, which will be a unique string for each simultaneous broadcast of an ongoing session.
+* See https://tokbox.com/developer/guides/archiving/#simultaneous-archives for more information.
+*
 * @property boolean $isHls
 * Whether the broadcast supports HLS.
 *
@@ -69,6 +73,8 @@ class Broadcast
     private $isLowLatency;
     /** @ignore */
     private $isDvr;
+    /** @ignore */
+    private $multiArchiveTag;
 
     /** @ignore */
     public function __construct($broadcastData, $options = array())
@@ -96,6 +102,10 @@ class Broadcast
         Validators::validateHasStreamMode($streamMode);
 
         $this->data = $broadcastData;
+
+        if (isset($this->data['multiArchiveTag'])) {
+            $this->multiArchiveTag = $this->data['multiArchiveTag'];
+        }
 
         $this->isStopped = $isStopped;
         $this->isHls = isset($this->data['settings']['hls']);
@@ -137,6 +147,8 @@ class Broadcast
                 return $this->isLowLatency;
             case 'isDvr':
                 return $this->isDvr;
+            case 'multiArchiveTag':
+                return $this->multiArchiveTag;
             default:
                 return null;
         }

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -302,6 +302,16 @@ class OpenTok
      *    <code>hasVideo</code> to false, the call to the <code>startArchive()</code> method results
      *    in an error.</li>
      *
+     *    <li><code>'multiArchiveTag'</code> (String) (Optional) &mdash; Set this to support recording multiple archives
+     *    for the same session simultaneously. Set this to a unique string for each simultaneous archive of an ongoing
+     *    session. You must also set this option when manually starting an archive
+     *    that is {https://tokbox.com/developer/guides/archiving/#automatic automatically archived}.
+     *    Note that the `multiArchiveTag` value is not included in the response for the methods to
+     *    {https://tokbox.com/developer/rest/#listing_archives list archives} and
+     *    {https://tokbox.com/developer/rest/#retrieve_archive_info retrieve archive information}.
+     *    If you do not specify a unique `multiArchiveTag`, you can only record one archive at a time for a given session.
+     *    {https://tokbox.com/developer/guides/archiving/#simultaneous-archives See Simultaneous archives}.</li>
+     *
      *    <li><code>'outputMode'</code> (OutputMode) &mdash; Whether all streams in the
      *    archive are recorded to a single file (<code>OutputMode::COMPOSED</code>, the default)
      *    or to individual files (<code>OutputMode::INDIVIDUAL</code>).</li>
@@ -636,6 +646,13 @@ class OpenTok
      *    manual modes, the broadcast composer includes streams based on
      *    <a href="https://tokbox.com/developer/guides/archive-broadcast-layout/#stream-prioritization-rules">stream
      *    prioritization rules</a>.</li>
+     *
+     *    <li><code>multiBroadcastTag</code> (String) (Optional) &mdash; Set this to support multiple broadcasts for
+     *    the same session simultaneously. Set this to a unique string for each simultaneous broadcast of an ongoing session.
+     *    Note that the `multiBroadcastTag` value is *not* included in the response for the methods to
+     *    {https://tokbox.com/developer/rest/#list_broadcasts list live streaming broadcasts} and
+     *    {https://tokbox.com/developer/rest/#get_info_broadcast get information about a live streaming broadcast}.
+     *    {https://tokbox.com/developer/guides/broadcast/live-streaming#simultaneous-broadcasts See Simultaneous broadcasts}.</li>
      *
      *    <li><code>outputs</code> (Array) &mdash;
      *      Defines the HLS broadcast and RTMP streams. You can provide the following keys:

--- a/tests/OpenTokTest/ArchiveTest.php
+++ b/tests/OpenTokTest/ArchiveTest.php
@@ -188,7 +188,7 @@ class ArchiveTest extends TestCase
         );
     }
 
-    public function testCannotAddStreamToArchiveWithNoAudioAndVideoe(): void
+    public function testCannotAddStreamToArchiveWithNoAudioAndVideo(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->setupOTWithMocks([[

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -541,6 +541,41 @@ class OpenTokTest extends TestCase
         $this->assertEquals('auto', $archive->streamMode);
     }
 
+    public function testStartsArchiveInMultiTagMode()
+    {
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'path' => 'v2/project/APIKEY/archive/session'
+        ]]);
+
+        $sessionId = '2_MX44NTQ1MTF-flR1ZSBOb3YgMTIgMDk6NDA6NTkgUFNUIDIwMTN-MC43NjU0Nzh-';
+
+        $archive = $this->opentok->startArchive($sessionId, ['multiArchiveTag' => 'my-key']);
+
+        // Assert
+        $this->assertCount(1, $this->historyContainer);
+
+        $request = $this->historyContainer[0]['request'];
+        $this->assertEquals('POST', strtoupper($request->getMethod()));
+        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
+        $this->assertEquals('https', $request->getUri()->getScheme());
+
+        $this->assertInstanceOf('OpenTok\Archive', $archive);
+        $this->assertEquals(0, $archive->duration);
+        $this->assertEquals('', $archive->reason);
+        $this->assertEquals('started', $archive->status);
+        $this->assertEquals(OutputMode::COMPOSED, $archive->outputMode);
+        $this->assertNull($archive->name);
+        $this->assertNull($archive->url);
+        $this->assertTrue($archive->hasVideo);
+        $this->assertTrue($archive->hasAudio);
+        $this->assertEquals('auto', $archive->streamMode);
+    }
+
     public function testStartsArchiveInManualMode(): void
     {
         // Arrange
@@ -1463,6 +1498,47 @@ class OpenTokTest extends TestCase
         $userAgent = $request->getHeaderLine('User-Agent');
         $this->assertNotEmpty($userAgent);
         $this->assertStringStartsWith('OpenTok-PHP-SDK/4.11.0', $userAgent);
+
+        $this->assertInstanceOf('OpenTok\Broadcast', $broadcast);
+        $this->assertIsString($broadcast->id);
+        $this->assertEquals($sessionId, $broadcast->sessionId);
+        $this->assertIsArray($broadcast->broadcastUrls);
+        $this->assertArrayHasKey('hls', $broadcast->broadcastUrls);
+        $this->assertIsString($broadcast->broadcastUrls['hls']);
+        $this->assertIsString($broadcast->hlsUrl);
+        $this->assertFalse($broadcast->isStopped);
+        $this->assertEquals('auto', $broadcast->streamMode);
+    }
+
+    public function testStartsBroadcastWithMultiBroadcastTag()
+    {
+        // Arrange
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'path' => '/v2/project/APIKEY/broadcast/session_layout-bestfit'
+        ]]);
+
+        $sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
+
+        $broadcast = $this->opentok->startBroadcast($sessionId, ['multiBroadcastTag' => 'my-broadcast-tag']);
+
+        $this->assertCount(1, $this->historyContainer);
+
+        $request = $this->historyContainer[0]['request'];
+        $this->assertEquals('POST', strtoupper($request->getMethod()));
+        $this->assertEquals('/v2/project/'.$this->API_KEY.'/broadcast', $request->getUri()->getPath());
+        $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
+        $this->assertEquals('https', $request->getUri()->getScheme());
+
+        $contentType = $request->getHeaderLine('Content-Type');
+        $this->assertNotEmpty($contentType);
+        $this->assertEquals('application/json', $contentType);
+
+        $authString = $request->getHeaderLine('X-OPENTOK-AUTH');
+        $this->assertEquals(true, TestHelpers::validateOpenTokAuthHeader($this->API_KEY, $this->API_SECRET, $authString));
 
         $this->assertInstanceOf('OpenTok\Broadcast', $broadcast);
         $this->assertIsString($broadcast->id);


### PR DESCRIPTION
This documents the ability to pass in a Multi Archive tag into the methods that start an Archive or a Broadcast.

## Description
This is mostly documentation.

## Motivation and Context
Missing feature that is live.

## How Has This Been Tested?
Two new tests added to make sure that adding custom options do not throw exceptions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
