### PR TITLE
fix: security bumps for composer firebase jwt and front end samples

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": "^7.2|^8.0",
         "ext-xml": "*",
         "johnstevenson/json-works": "~1.1",
-        "firebase/php-jwt": "^5.0",
+        "firebase/php-jwt": "^6.0",
         "guzzlehttp/guzzle": "~6.0|~7.0",
       "ext-json": "*"
     },

--- a/sample/Archiving/templates/base.html
+++ b/sample/Archiving/templates/base.html
@@ -7,11 +7,11 @@
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width">
 
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0/css/bootstrap.min.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0/css/bootstrap-theme.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/css/bootstrap.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/css/bootstrap-theme.min.css">
   <link rel="stylesheet" href="css/sample.css">
 
-  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.5.0/jquery.min.js"></script>
 </head>
 <body>
 
@@ -24,6 +24,6 @@
 
   {% block content %}{% endblock %}
 
-  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0/js/bootstrap.min.js"></script>
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/js/bootstrap.min.js"></script>
 </body>
 </html>

--- a/sample/SipCall/templates/index.php
+++ b/sample/SipCall/templates/index.php
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Muli:300,300italic" type='text/css'>
     <link rel='stylesheet' href='/stylesheets/style.css' />
     <link rel='stylesheet' href='/stylesheets/pattern.css' />
-    <script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.5.0.min.js"></script>
     <script src="https://static.opentok.com/v2/js/opentok.min.js"></script>
     <script>
       var sessionId = "<?php echo $sessionId ?>";

--- a/src/OpenTok/Util/Client.php
+++ b/src/OpenTok/Util/Client.php
@@ -108,7 +108,7 @@ class Client
             'exp' => time() + (5 * 60),
             'jti' => uniqid(),
         );
-        return JWT::encode($token, $this->apiSecret);
+        return JWT::encode($token, $this->apiSecret, 'HS256');
     }
 
     // General API Requests

--- a/tests/OpenTokTest/TestHelpers.php
+++ b/tests/OpenTokTest/TestHelpers.php
@@ -2,6 +2,7 @@
 
 namespace OpenTokTest;
 
+use Firebase\JWT\Key;
 use GuzzleHttp\Psr7\Response;
 use \Firebase\JWT\JWT;
 
@@ -40,7 +41,7 @@ class TestHelpers
         }
 
         try {
-            $decodedToken = JWT::decode($token, $apiSecret, array('HS256'));
+            $decodedToken = JWT::decode($token, new Key($apiSecret, 'HS256'));
         } catch (\Exception $e) {
             return false;
         }


### PR DESCRIPTION
This PR directly to main takes care of several security issues raised by Github bots:

* Bootstrap update in sample app
* jQuery update in sample app
* Compser bump in PHP to get the latest firebase jwt library.
