### PR TITLE
Added optional properties when starting archiving

### DIFF
--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -454,6 +454,14 @@ class OpenTok
             'resolution' => null,
             'streamMode' => StreamMode::AUTO,
         );
+        if (isset($options['multiArchiveTag'])) {
+            $defaults['multiArchiveTag'] = $options['multiArchiveTag'];
+            Validators::validateArchiveMultiArchiveTag($defaults['multiArchiveTag']);
+        }
+        if (isset($options['layout'])) {
+            $defaults['layout'] = $options['layout'];
+            Validators::validateArchiveLayout($defaults['layout']);
+        }
         $options = array_merge($defaults, array_intersect_key($options, $defaults));
         list($name, $hasVideo, $hasAudio, $outputMode, $resolution, $streamMode) = array_values($options);
 

--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -201,6 +201,22 @@ class Validators
             );
         }
     }
+    public static function validateArchiveMultiArchiveTag($multiArchiveTag)
+    {
+        if ($multiArchiveTag != null && !is_string($multiArchiveTag) /* TODO: length? */) {
+            throw new InvalidArgumentException(
+                'The multiArchiveTag was not a string: ' . print_r($multiArchiveTag, true)
+            );
+        }
+    }
+    public static function validateArchiveLayout($layout)
+    {
+        if ($layout != null && !is_array($layout)) {
+            throw new InvalidArgumentException(
+                'The layout was not an array: ' . print_r($layout, true)
+            );
+        }
+    }
     public static function validateArchiveData($archiveData)
     {
         if (!self::$archiveSchemaUri) {


### PR DESCRIPTION
Added optional properties when starting archiving

## Description
For video recording, added support for multiArchiveTag and layout properties. In the current implementation, the array_intersect_key function removes all received options except the default ones.

## Motivation and Context
Bug fix

## How Has This Been Tested?
Test suite passes

## Example Output or Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
