### PR TITLE
Add end-to-end encryption when creating session.

### DIFF
--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -2,7 +2,6 @@
 
 namespace OpenTok;
 
-use OpenTok\Layout;
 use OpenTok\Util\Client;
 use OpenTok\Util\Validators;
 use OpenTok\Exception\InvalidArgumentException;
@@ -166,6 +165,9 @@ class OpenTok
     *    (either automatically or not), you must set the <code>mediaMode</code> key to
     *    <code>MediaMode::ROUTED</code>.</li>
     *
+    *    <li><code>'e2ee'</code> (Boolean) &mdash; Whether to enable end-to-end encryption for the
+    *    OpenTok session.</code>.</li>
+    *
     *    <li><code>'location'</code> (String) &mdash; An IP address that the OpenTok servers
     *    will use to situate the session in its global network. If you do not set a location hint,
     *    the OpenTok servers will be based on the first client connecting to the session.</li>
@@ -212,11 +214,11 @@ class OpenTok
     {
         if (
             array_key_exists('archiveMode', $options) &&
-            $options['archiveMode'] != ArchiveMode::MANUAL
+            $options['archiveMode'] !== ArchiveMode::MANUAL
         ) {
             if (
                 array_key_exists('mediaMode', $options) &&
-                $options['mediaMode'] != MediaMode::ROUTED
+                $options['mediaMode'] !== MediaMode::ROUTED
             ) {
                 throw new InvalidArgumentException('A session must be routed to be archived.');
             } else {
@@ -224,14 +226,20 @@ class OpenTok
             }
         }
 
+        if (array_key_exists('e2ee', $options) && $options['e2ee']) {
+            $options['e2ee'] = 'true';
+        }
+
         // unpack optional arguments (merging with default values) into named variables
         $defaults = array(
             'mediaMode' => MediaMode::RELAYED,
             'archiveMode' => ArchiveMode::MANUAL,
-            'location' => null
+            'location' => null,
+            'e2ee' => 'false',
         );
+
         $options = array_merge($defaults, array_intersect_key($options, $defaults));
-        list($mediaMode, $archiveMode, $location) = array_values($options);
+        list($mediaMode, $archiveMode, $location, $e2ee) = array_values($options);
 
         // validate arguments
         Validators::validateMediaMode($mediaMode);
@@ -251,7 +259,8 @@ class OpenTok
         return new Session($this, (string)$sessionId, array(
             'location' => $location,
             'mediaMode' => $mediaMode,
-            'archiveMode' => $archiveMode
+            'archiveMode' => $archiveMode,
+            'e2ee' => $e2ee
         ));
     }
 

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -227,6 +227,15 @@ class OpenTok
         }
 
         if (array_key_exists('e2ee', $options) && $options['e2ee']) {
+
+            if (array_key_exists('mediaMode', $options) && $options['mediaMode'] !== MediaMode::ROUTED) {
+                throw new InvalidArgumentException('MediaMode must be routed in order to enable E2EE');
+            }
+
+            if (array_key_exists('archiveMode', $options) && $options['archiveMode'] === ArchiveMode::ALWAYS) {
+                throw new InvalidArgumentException('ArchiveMode cannot be set to always when using E2EE');
+            }
+
             $options['e2ee'] = 'true';
         }
 

--- a/src/OpenTok/Session.php
+++ b/src/OpenTok/Session.php
@@ -160,10 +160,10 @@ class Session
     }
 
     /**
-     * @return mixed
+     * @return bool
      */
     public function getE2EE(): bool
     {
-        return $this->e2ee;
+        return (bool)$this->e2ee;
     }
 }

--- a/src/OpenTok/Session.php
+++ b/src/OpenTok/Session.php
@@ -32,16 +32,25 @@ class Session
      * @internal
      */
     protected $opentok;
+    /**
+     * @internal
+     */
+    protected $e2ee;
 
     /**
      * @internal
      */
     public function __construct($opentok, $sessionId, $properties = array())
     {
-        // unpack arguments
-        $defaults = array('mediaMode' => MediaMode::ROUTED, 'archiveMode' => ArchiveMode::MANUAL, 'location' => null);
+        $defaults = [
+            'mediaMode' => MediaMode::ROUTED,
+            'archiveMode' => ArchiveMode::MANUAL,
+            'location' => null,
+            'e2ee' => false
+        ];
+
         $properties = array_merge($defaults, array_intersect_key($properties, $defaults));
-        list($mediaMode, $archiveMode, $location) = array_values($properties);
+        list($mediaMode, $archiveMode, $location, $e2ee) = array_values($properties);
 
         Validators::validateOpenTok($opentok);
         Validators::validateSessionId($sessionId);
@@ -54,6 +63,7 @@ class Session
         $this->location = $location;
         $this->mediaMode = $mediaMode;
         $this->archiveMode = $archiveMode;
+        $this->e2ee = $e2ee;
     }
 
     /**
@@ -147,5 +157,13 @@ class Session
     public function generateToken($options = array())
     {
         return $this->opentok->generateToken($this->sessionId, $options);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getE2EE(): bool
+    {
+        return $this->e2ee;
     }
 }

--- a/src/OpenTok/Session.php
+++ b/src/OpenTok/Session.php
@@ -160,6 +160,9 @@ class Session
     }
 
     /**
+     * Whether <a href="https://tokbox.com/developer/guides/end-to-end-encryption">end-to-end encryption</a>
+     * is set for the session.
+     *
      * @return bool
      */
     public function getE2EE(): bool

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -272,6 +272,48 @@ class OpenTokTest extends TestCase
         );
     }
 
+    public function testCannotStartE2EESessionWithWrongMediaMode(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage('MediaMode must be routed in order to enable E2EE');
+
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'text/xml'
+            ],
+            'path' => 'session/create/relayed'
+        ]]);
+
+        $session = $this->opentok->createSession(
+            [
+                'mediaMode' => MediaMode::RELAYED,
+                'e2ee' => true
+            ]
+        );
+    }
+
+    public function testCannotStartE2EESessionWithWrongArchiveMode(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage('ArchiveMode cannot be set to always when using E2EE');
+
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'text/xml'
+            ],
+            'path' => 'session/create/relayed'
+        ]]);
+
+        $session = $this->opentok->createSession(
+            [
+                'archiveMode' => ArchiveMode::ALWAYS,
+                'e2ee' => true
+            ]
+        );
+    }
+
     private function getPostField($request, $targetKey)
     {
         $params = array_map(function ($item) {

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -18,6 +18,7 @@ use GuzzleHttp\HandlerStack;
 use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Handler\MockHandler;
 use OpenTok\Exception\InvalidArgumentException;
+use OpenTok\Session;
 
 define('OPENTOK_DEBUG', true);
 
@@ -218,9 +219,53 @@ class OpenTokTest extends TestCase
         $p2p_preference = $this->getPostField($request, 'p2p.preference');
         $this->assertEquals('enabled', $p2p_preference);
 
+        $e2ee = $this->getPostField($request, 'e2ee');
+        $this->assertEquals('false', $e2ee);
+
         $this->assertInstanceOf('OpenTok\Session', $session);
         // NOTE: this is an actual sessionId from the recorded response, this doesn't correspond to
         // the API Key and API Secret used to create the session.
+        $this->assertEquals(
+            '2_MX4xNzAxMjYzMX4xMjcuMC4wLjF-V2VkIEZlYiAyNiAxODo1NzoyNCBQU1QgMjAxNH4wLjU0MDU4ODc0fg',
+            $session->getSessionId()
+        );
+    }
+
+    public function testCreatesE2EESession(): void
+    {
+        // Arrange
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'text/xml'
+            ],
+            'path' => 'session/create/relayed'
+        ]]);
+
+        $session = $this->opentok->createSession(['e2ee' => true]);
+
+        $this->assertCount(1, $this->historyContainer);
+
+        $request = $this->historyContainer[0]['request'];
+        $this->assertEquals('POST', strtoupper($request->getMethod()));
+        $this->assertEquals('/session/create', $request->getUri()->getPath());
+        $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
+        $this->assertEquals('https', $request->getUri()->getScheme());
+
+        $authString = $request->getHeaderLine('X-OPENTOK-AUTH');
+        $this->assertEquals(true, TestHelpers::validateOpenTokAuthHeader($this->API_KEY, $this->API_SECRET, $authString));
+
+        $userAgent = $request->getHeaderLine('User-Agent');
+        $this->assertNotEmpty($userAgent);
+        $this->assertStringStartsWith('OpenTok-PHP-SDK/4.12.0', $userAgent);
+
+        $p2p_preference = $this->getPostField($request, 'p2p.preference');
+        $this->assertEquals('enabled', $p2p_preference);
+
+        $e2ee = $this->getPostField($request, 'e2ee');
+        $this->assertEquals('true', $e2ee);
+
+        $this->assertInstanceOf(Session::class, $session);
         $this->assertEquals(
             '2_MX4xNzAxMjYzMX4xMjcuMC4wLjF-V2VkIEZlYiAyNiAxODo1NzoyNCBQU1QgMjAxNH4wLjU0MDU4ODc0fg',
             $session->getSessionId()

--- a/tests/OpenTokTest/SessionTest.php
+++ b/tests/OpenTokTest/SessionTest.php
@@ -2,14 +2,10 @@
 
 namespace OpenTokTest;
 
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
 use OpenTok\OpenTok;
 use OpenTok\Session;
 use OpenTok\MediaMode;
 use OpenTok\ArchiveMode;
-use OpenTok\Util\Client;
 use PHPUnit\Framework\TestCase;
 
 class SessionTest extends TestCase
@@ -120,6 +116,20 @@ class SessionTest extends TestCase
             array('SESSIONID', array( 'location' => '127.0.0.1', 'mediaMode' => 'NOTAMODE' ) ),
             array('SESSIONID', array( 'location' => 'NOTALOCATION', 'mediaMode' => MediaMode::RELAYED ) )
         );
+    }
+
+    public function testInitialzationWithoutE2ee()
+    {
+        $sessionId = 'SESSIONID';
+        $session = new Session($this->opentok, $sessionId);
+        $this->assertEquals(false, $session->getE2EE());
+    }
+
+    public function testInitialzationWithE2ee()
+    {
+        $sessionId = 'SESSIONID';
+        $session = new Session($this->opentok, $sessionId, ['e2ee' => true]);
+        $this->assertEquals(true, $session->getE2EE());
     }
 
     public function testInitializationWithExtraneousParams()


### PR DESCRIPTION
This PR adds the end to end encryption flag when starting an OpenTok Session.

## Description
See the docs for more context:
https://tokbox.com/developer/guides/end-to-end-encryption/

## Motivation and Context
New features being rolled into our SDKs

## How Has This Been Tested?
Added new test and modified existing one to make sure defaults are read properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
