### PR TITLE
Add php 8.1 and php 8.2 to github actions build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
             - ubuntu-latest
         strategy:
             matrix:
-                php: ['7.2', '7.3', '7.4', '8.0']
+                php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         steps:
             - name: Configure Git
               if: ${{ matrix.os == 'windows-latest' }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding recent versions of PHP to build matrix

## Motivation and Context
PHP 8.1 is out for 1.5 years, php 8.2 for half a year. Still they aren't part of the automatic test matrix

## How Has This Been Tested?
-

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
