### PR TITLE
Fix Validator::isAssoc()

### DIFF
--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -429,16 +429,16 @@ class Validators
         throw new InvalidArgumentException('DTMF digits can only support 0-9, p, #, and * characters');
     }
 
-    // Helpers
-
-    // credit: http://stackoverflow.com/a/173479
     public static function isAssoc($arr): bool
     {
-        if (array() === $arr) {
-            return false;
+        if (!function_exists('array_is_list')) {
+            if ($arr === []) {
+                return true;
+            }
+            return array_keys($arr) === range(0, count($arr) - 1);
         }
 
-        return array_keys($arr) !== range(0, count($arr) - 1);
+        return array_is_list($arr);
     }
 
     protected static function decodeSessionId($sessionId)

--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -421,12 +421,12 @@ class Validators
 
     public static function validateLayoutClassListItem($layoutClassList)
     {
-        if (!is_string($layoutClassList['id'])) {
-            throw new InvalidArgumentException('Each element in the streamClassArray must have an id string.');
-        }
-
         if (!is_array($layoutClassList)) {
             throw new InvalidArgumentException('Each element in the streamClassArray must have a layoutClassList array.');
+        }
+
+        if (!is_string($layoutClassList['id'])) {
+            throw new InvalidArgumentException('Each element in the streamClassArray must have an id string.');
         }
 
         if (!isset($layoutClassList['layoutClassList'])) {

--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -428,6 +428,11 @@ class Validators
         if (!is_array($layoutClassList)) {
             throw new InvalidArgumentException('Each element in the streamClassArray must have a layoutClassList array.');
         }
+
+        if (!isset($layoutClassList['layoutClassList'])) {
+            throw new InvalidArgumentException('layoutClassList not set in array');
+        }
+
         if (!is_array($layoutClassList['layoutClassList'])) {
             throw new InvalidArgumentException('Each element in the layoutClassList array must be a string (defining class names).');
         }

--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -432,13 +432,16 @@ class Validators
     public static function isAssoc($arr): bool
     {
         if (!function_exists('array_is_list')) {
-            if ($arr === []) {
-                return true;
+            function array_is_list(array $arr): bool
+            {
+                if ($arr === []) {
+                    return true;
+                }
+                return array_keys($arr) === range(0, count($arr) - 1);
             }
-            return array_keys($arr) === range(0, count($arr) - 1);
         }
 
-        return array_is_list($arr);
+        return !array_is_list($arr);
     }
 
     protected static function decodeSessionId($sessionId)

--- a/tests/OpenTokTest/LayoutTest.php
+++ b/tests/OpenTokTest/LayoutTest.php
@@ -3,6 +3,7 @@
 namespace OpenTokTest;
 
 use OpenTok\Layout;
+use OpenTok\Util\Validators;
 use PHPStan\Testing\TestCase;
 
 class LayoutTest extends TestCase
@@ -19,6 +20,14 @@ class LayoutTest extends TestCase
         foreach ($layouts as $type => $object) {
             $this->assertSame(['type' => $type], $object->toArray());
         }
+    }
+
+    public function testWillValidateLayout(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $object = ['bestFit' => true];
+
+        Validators::validateLayout($object);
     }
 
     public function testStylesheetIsInSerializedArrayIfCustom()

--- a/tests/OpenTokTest/Validators/ValidatorsTest.php
+++ b/tests/OpenTokTest/Validators/ValidatorsTest.php
@@ -3,6 +3,7 @@
 namespace OpenTokTest\Validators;
 
 use OpenTok\Exception\InvalidArgumentException;
+use OpenTok\Util\Client;
 use OpenTok\Util\Validators;
 use PHPUnit\Framework\TestCase;
 
@@ -218,6 +219,72 @@ class ValidatorsTest extends TestCase
         ];
 
         Validators::validateLayoutClassListItem($layoutClassList);
+    }
+    public function testValidateClient(): void
+    {
+        $client = new Client();
+        Validators::validateClient($client);
+
+        // No exception, which was the test so fake a pass
+        $this->assertTrue(true);
+    }
+
+    public function testExceptionOnInvalidClient(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $client = new \stdClass();
+        Validators::validateClient($client);
+    }
+
+    public function testThrowsErrorOnInvalidStreamMode(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $streamMode = ['auto'];
+        Validators::validateHasStreamMode($streamMode);
+    }
+
+    public function testValidateSignalPayload(): void
+    {
+        $validPayload = ['type' => 'signal_type', 'data' => 'signal_data'];
+        $this->assertNull(Validators::validateSignalPayload($validPayload));
+
+        $invalidDataPayload = ['type' => 'signal_type', 'data' => 123];
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Signal Payload cannot be null:");
+        Validators::validateSignalPayload($invalidDataPayload);
+
+        $invalidTypePayload = ['type' => null, 'data' => 'signal_data'];
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Signal Payload cannot be null:");
+        Validators::validateSignalPayload($invalidTypePayload);
+
+        // Invalid payload: both type and data are null
+        $invalidBothPayload = ['type' => null, 'data' => null];
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Signal Payload cannot be null:");
+        Validators::validateSignalPayload($invalidBothPayload);
+    }
+
+    /**
+     * @dataProvider connectionIdProvider
+     */
+    public function testConnectionId($input, $expectException): void
+    {
+        if ($expectException) {
+            $this->expectException(\InvalidArgumentException::class);
+        }
+
+        Validators::validateConnectionId($input);
+        $this->assertTrue(true);
+    }
+
+    public function connectionIdProvider(): array
+    {
+        return [
+            [['this' => 'is not a string'], true],
+            ['', true],
+            ['valid_connection_string', false]
+        ];
     }
 
     public function resolutionProvider(): array

--- a/tests/OpenTokTest/Validators/ValidatorsTest.php
+++ b/tests/OpenTokTest/Validators/ValidatorsTest.php
@@ -72,28 +72,28 @@ class ValidatorsTest extends TestCase
         Validators::validateForceMuteAllOptions($options);
     }
 
-    public function testIsAssocWithValidArray(): void
+    public function testIsAssocWithIndexedArray(): void
     {
-        $haystack = [
-            'one' => '1',
-            'two' => '2',
-            'three' => '3',
-            'four' => '4'
-        ];
-
-        $this->assertTrue(Validators::isAssoc($haystack));
+        $array = [1, 2, 3, 4];
+        $this->assertFalse(Validators::isAssoc($array));
     }
 
-    public function testIsAssocWithInvalidArray(): void
+    public function testIsAssocWithAssociativeArray(): void
     {
-        $haystack = [
-            'one',
-            'two',
-            'three',
-            'four'
-        ];
+        $array = ['a' => 1, 'b' => 2, 'c' => 3];
+        $this->assertTrue(Validators::isAssoc($array));
+    }
 
-        $this->assertFalse(Validators::isAssoc($haystack));
+    public function testIsAssocWithMixedKeysArray(): void
+    {
+        $array = [1, 'a' => 2, 3];
+        $this->assertTrue(Validators::isAssoc($array));
+    }
+
+    public function testIsAssocWithEmptyArray(): void
+    {
+        $array = [];
+        $this->assertFalse(Validators::isAssoc($array));
     }
 
     public function testWillFailWhenStreamIdsAreNotCorrect(): void
@@ -176,6 +176,48 @@ class ValidatorsTest extends TestCase
         }
 
         Validators::validateResolution($resolution);
+    }
+
+    public function testValidLayoutClassListItem(): void
+    {
+        $layoutClassList = [
+            'id' => 'example_id',
+            'layoutClassList' => ['class1', 'class2']
+        ];
+
+        $this->assertNull(Validators::validateLayoutClassListItem($layoutClassList));
+    }
+
+    public function testInvalidIdType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $layoutClassList = [
+            'id' => 123,
+            'layoutClassList' => ['class1', 'class2']
+        ];
+
+        Validators::validateLayoutClassListItem($layoutClassList);
+    }
+
+    public function testMissingLayoutClassList(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $layoutClassList = [
+            'id' => 'example_id'
+        ];
+
+        Validators::validateLayoutClassListItem($layoutClassList);
+    }
+
+    public function testInvalidLayoutClassListType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $layoutClassList = [
+            'id' => 'example_id',
+            'layoutClassList' => 'invalid_class'
+        ];
+
+        Validators::validateLayoutClassListItem($layoutClassList);
     }
 
     public function resolutionProvider(): array

--- a/tests/OpenTokTest/Validators/ValidatorsTest.php
+++ b/tests/OpenTokTest/Validators/ValidatorsTest.php
@@ -67,7 +67,7 @@ class ValidatorsTest extends TestCase
                 'streamId1',
                 'streamId2'
             ],
-            'active' => true
+            'active'          => true
         ];
 
         Validators::validateForceMuteAllOptions($options);
@@ -106,7 +106,7 @@ class ValidatorsTest extends TestCase
                 3536,
                 'streamId2'
             ],
-            'active' => true
+            'active'          => true
         ];
 
         Validators::validateForceMuteAllOptions($options);
@@ -121,7 +121,7 @@ class ValidatorsTest extends TestCase
                 'streamId1',
                 'streamId2'
             ],
-            'active' => 'true'
+            'active'          => 'true'
         ];
 
         Validators::validateForceMuteAllOptions($options);
@@ -133,7 +133,7 @@ class ValidatorsTest extends TestCase
 
         $options = [
             'excludedStreams' => 'streamIdOne',
-            'active' => false
+            'active'          => false
         ];
 
         Validators::validateForceMuteAllOptions($options);
@@ -143,7 +143,7 @@ class ValidatorsTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
         $websocketConfig = [
-            'uri' => 'ws://valid-websocket',
+            'uri'     => 'ws://valid-websocket',
             'streams' => [
                 '525503c7-913e-43a1-84b4-31b2e9fe668b',
                 '14026813-4f50-4a5a-9b72-fea25430916d'
@@ -163,20 +163,27 @@ class ValidatorsTest extends TestCase
             ]
         ];
         Validators::validateWebsocketOptions($websocketConfig);
-     }
+    }
 
     /**
      * @dataProvider resolutionProvider
      */
     public function testValidResolutions($resolution, $isValid): void
     {
-        if (!$isValid) {
+        if ( ! $isValid) {
             $this->expectException(InvalidArgumentException::class);
         } else {
             $this->expectNotToPerformAssertions();
         }
 
         Validators::validateResolution($resolution);
+    }
+
+    public function testValidLayoutClassListItemErrorOnString(): void
+    {
+        $input = 'example_id';
+        $this->expectException(\InvalidArgumentException::class);
+        Validators::validateLayoutClassListItem($input);
     }
 
     public function testValidLayoutClassListItem(): void


### PR DESCRIPTION
Quick bugfix to either use PHP8.1 `array_is_list()` or fall back to correct logic.