### PR TITLE
Feature/broadcast rtmp bitrate

### DIFF
--- a/src/OpenTok/Broadcast.php
+++ b/src/OpenTok/Broadcast.php
@@ -48,6 +48,9 @@ use OpenTok\Util\Validators;
 * @property string $status
 * Broadcast state. Either `started` or `stopped`
 *
+* @property string $maxBitRate
+* Max Bitrate allowed for the broadcast composing. Must be between 400000 and 2000000
+*
 * @property boolean $isLowLatency
 * Whether the broadcast supports low-latency mode for the HLS stream.
 *

--- a/src/OpenTok/Broadcast.php
+++ b/src/OpenTok/Broadcast.php
@@ -91,6 +91,8 @@ class Broadcast
     private $hasVideo;
     /** @ignore */
     private $status;
+    /** @ignore */
+    private $maxBitRate;
 
     public function __construct($broadcastData, $options = array())
     {
@@ -121,6 +123,10 @@ class Broadcast
 
         if (isset($this->data['multiBroadcastTag'])) {
             $this->multiBroadcastTag = $this->data['multiBroadcastTag'];
+        }
+
+        if (isset($this->data['maxBitRate'])) {
+            $this->maxBitRate = $this->data['maxBitRate'];
         }
 
         if (isset($this->data['status'])) {
@@ -179,6 +185,8 @@ class Broadcast
                 return $this->hasVideo;
             case 'status':
                 return $this->status;
+            case 'maxBitRate':
+                return $this->maxBitRate;
             default:
                 return null;
         }

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -823,6 +823,9 @@ class OpenTok
      *    "1920x1080" (FHD landscape), "480x640" (SD portrait), "720x1280" (HD portrait), or "1080x1920"
      *    (FHD portrait).</li>
      *
+     *    <li><code>maxBitRate</code> &mdash; Max Bitrate allowed for the broadcast composing. Must be between
+     *    400000 and 2000000.</li>
+     *
      *    <li><code>outputs</code> (Array) &mdash;
      *      Defines the HLS broadcast and RTMP streams. You can provide the following keys:
      *      <ul>

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -864,6 +864,10 @@ class OpenTok
         // not preferred to depend on that in the SDK because its then harder to garauntee backwards
         // compatibility
 
+        if (isset($options['maxBitRate'])) {
+            Validators::validateBroadcastBitrate($options['maxBitRate']);
+        }
+
         if (isset($options['resolution'])) {
             Validators::validateResolution($options['resolution']);
         }
@@ -882,6 +886,7 @@ class OpenTok
             'hasVideo' => true,
             'streamMode' => 'auto',
             'resolution' => '640x480',
+            'maxBitRate' => 2000000,
 	        'outputs' => [
 				'hls' => [
 	                'dvr' => false,
@@ -892,17 +897,13 @@ class OpenTok
 
         $options = array_merge($defaults, $options);
 
-        list($layout, $hasAudio, $hasVideo, $streamMode) = array_values($options);
-
-        // validate arguments
         Validators::validateSessionId($sessionId);
-        Validators::validateLayout($layout);
-        Validators::validateHasStreamMode($streamMode);
+        Validators::validateLayout($options['layout']);
+        Validators::validateHasStreamMode($options['streamMode']);
 
-        // make API call
         $broadcastData = $this->client->startBroadcast($sessionId, $options);
 
-        return new Broadcast($broadcastData, array('client' => $this->client));
+        return new Broadcast($broadcastData, ['client' => $this->client]);
     }
 
     /**
@@ -910,7 +911,7 @@ class OpenTok
      *
      * @param String $broadcastId The ID of the broadcast.
      */
-    public function stopBroadcast($broadcastId)
+    public function stopBroadcast($broadcastId): Broadcast
     {
         // validate arguments
         Validators::validateBroadcastId($broadcastId);
@@ -930,7 +931,7 @@ class OpenTok
      *
      * @return Broadcast An object with properties defining the broadcast.
      */
-    public function getBroadcast($broadcastId)
+    public function getBroadcast($broadcastId): Broadcast
     {
         Validators::validateBroadcastId($broadcastId);
 

--- a/src/OpenTok/Util/Validators.php
+++ b/src/OpenTok/Util/Validators.php
@@ -486,4 +486,15 @@ class Validators
         }
         return $data;
     }
+
+    public static function validateBroadcastBitrate($maxBitRate): void
+    {
+        if (!is_int($maxBitRate)) {
+            throw new \InvalidArgumentException('Max Bitrate must be a number');
+        }
+
+        if ($maxBitRate < 400000 && $maxBitRate > 2000000) {
+            throw new \OutOfBoundsException('Max Bitrate must be between 400000 and 2000000');
+        }
+    }
 }

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -1725,7 +1725,6 @@ class OpenTokTest extends TestCase
 
     public function testStartsBroadcast(): void
     {
-        // Arrange
         $this->setupOTWithMocks([[
             'code' => 200,
             'headers' => [
@@ -1734,14 +1733,10 @@ class OpenTokTest extends TestCase
             'path' => '/v2/project/APIKEY/broadcast/session_layout-bestfit'
         ]]);
 
-        // This sessionId was generated using a different apiKey, but this method doesn't do any
-        // decoding to check, so it's fine.
         $sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
 
-        // Act
         $broadcast = $this->opentok->startBroadcast($sessionId);
 
-        // Assert
         $this->assertCount(1, $this->historyContainer);
 
         $request = $this->historyContainer[0]['request'];
@@ -1767,9 +1762,34 @@ class OpenTokTest extends TestCase
         $this->assertEquals('auto', $broadcast->streamMode);
     }
 
+    public function testStartsBroadcastWithMaxBitrate(): void
+    {
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'path' => '/v2/project/APIKEY/broadcast/session_layout-bestfit'
+        ]]);
+
+        $sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
+
+        $broadcast = $this->opentok->startBroadcast($sessionId, [
+            'maxBitRate' => 2000000
+        ]);
+
+        $this->assertIsString($broadcast->id);
+        $this->assertEquals($sessionId, $broadcast->sessionId);
+        $this->assertIsArray($broadcast->broadcastUrls);
+        $this->assertArrayHasKey('hls', $broadcast->broadcastUrls);
+        $this->assertIsString($broadcast->broadcastUrls['hls']);
+        $this->assertIsString($broadcast->hlsUrl);
+        $this->assertFalse($broadcast->isStopped);
+        $this->assertEquals(2000000, $broadcast->maxBitRate);
+    }
+
     public function testStartsBroadcastWithMultiBroadcastTag(): void
     {
-        // Arrange
         $this->setupOTWithMocks([[
             'code' => 200,
             'headers' => [

--- a/tests/mock/v2/project/APIKEY/broadcast/BROADCASTID/start_default
+++ b/tests/mock/v2/project/APIKEY/broadcast/BROADCASTID/start_default
@@ -24,6 +24,7 @@
   "status":"started",
   "partnerId":854511,
   "maxDuration":5400,
+  "maxBitRate": 2000000,
   "resolution": "1280x720",
   "streamMode": "auto",
   "hasAudio": true,

--- a/tests/mock/v2/project/APIKEY/broadcast/BROADCASTID/start_dvr
+++ b/tests/mock/v2/project/APIKEY/broadcast/BROADCASTID/start_dvr
@@ -21,6 +21,7 @@
   "status":"started",
   "partnerId":854511,
   "maxDuration":5400,
+  "maxBitRate": 2000000,
   "resolution": "1280x720",
   "streamMode": "auto",
   "hasAudio": true,

--- a/tests/mock/v2/project/APIKEY/broadcast/BROADCASTID/start_ll
+++ b/tests/mock/v2/project/APIKEY/broadcast/BROADCASTID/start_ll
@@ -24,6 +24,7 @@
   "status":"started",
   "partnerId":854511,
   "maxDuration":5400,
+  "maxBitRate": 2000000,
   "resolution": "1280x720",
   "streamMode": "auto",
   "hasAudio": true,

--- a/tests/mock/v2/project/APIKEY/broadcast/session_layout-bestfit
+++ b/tests/mock/v2/project/APIKEY/broadcast/session_layout-bestfit
@@ -20,6 +20,7 @@
   "status":"started",
   "partnerId":854511,
   "maxDuration":5400,
+  "maxBitRate": 2000000,
   "resolution": "1280x720",
   "streamMode": "auto"
 }

--- a/tests/mock/v2/project/APIKEY/broadcast/session_manual_stream
+++ b/tests/mock/v2/project/APIKEY/broadcast/session_manual_stream
@@ -20,6 +20,7 @@
   "status":"started",
   "partnerId":854511,
   "maxDuration":5400,
+  "maxBitRate": 2000000,
   "resolution": "1280x720",
   "streamMode": "manual"
 }


### PR DESCRIPTION
This PR adds the ability to choose a maximum Bitrate for new Broadcasts.

## Motivation and Context
Evolution of OpenTok SDK

## How Has This Been Tested?
New test to pull out the bitrate with expected default value has been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
