### PR TITLE
Added legacy transformation, currently no tests for new JWT structure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
             - ubuntu-latest
         strategy:
             matrix:
-                php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+                php: ['8.1', '8.2', '8.3']
         steps:
             - name: Configure Git
               if: ${{ matrix.os == 'windows-latest' }}

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "johnstevenson/json-works": "~1.1",
         "firebase/php-jwt": "^6.0",
         "guzzlehttp/guzzle": "~6.0|~7.0",
-      "ext-json": "*"
+      "ext-json": "*",
+        "vonage/jwt": "^0.5.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.4|^8.0",
@@ -54,6 +55,11 @@
         "psr-4": {
             "OpenTok\\": "src/OpenTok",
             "OpenTokTest\\": "tests/OpenTokTest"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
         }
     }
 }

--- a/sample/Archiving/README.md
+++ b/sample/Archiving/README.md
@@ -56,7 +56,7 @@ $app->get('/host', function () use ($app, $sessionId) {
 
     $token = $app->opentok->generateToken($sessionId, array(
         'role' => Role::MODERATOR
-    ));
+    ), true);
 
     $app->render('host.html', array(
         'apiKey' => $app->apiKey,

--- a/src/OpenTok/Session.php
+++ b/src/OpenTok/Session.php
@@ -154,9 +154,9 @@ class Session
      *
      * @return string The token string.
      */
-    public function generateToken($options = array())
+    public function generateToken($options = array(), bool $legacy = false)
     {
-        return $this->opentok->generateToken($this->sessionId, $options);
+        return $this->opentok->generateToken($this->sessionId, $options, $legacy);
     }
 
     /**

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -2,6 +2,8 @@
 
 namespace OpenTokTest;
 
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Token\Plain;
 use OpenTok\Render;
 use OpenTok\Role;
 use OpenTok\Layout;
@@ -740,6 +742,31 @@ class OpenTokTest extends TestCase
         $token = $this->opentok->generateToken('SESSIONID', array('role' => 'notarole'), true);
     }
 
+    public function testWillCreateJwt(): void
+    {
+        $openTok = new OpenTok('my-api-key', 'my-super-long-and-cool-api-secret');
+        $token = $openTok->generateToken('some-token-value');
+
+        $config = Configuration::forSymmetricSigner(
+            new \Lcobucci\JWT\Signer\Hmac\Sha256(),
+            \Lcobucci\JWT\Signer\Key\InMemory::plainText('my-super-long-and-cool-api-secret')
+        );
+
+        $token = $config->parser()->parse($token);
+        $this->assertInstanceOf(Plain::class, $token);
+
+        $this->assertTrue($config->validator()->validate($token, new \Lcobucci\JWT\Validation\Constraint\SignedWith(
+            $config->signer(),
+            $config->signingKey()
+        )));
+
+        $this->assertEquals('my-api-key', $token->claims()->get('iss'));
+        $this->assertEquals('some-token-value', $token->claims()->get('session_id'));
+        $this->assertEquals('publisher', $token->claims()->get('role'));
+        $this->assertEquals('project', $token->claims()->get('ist'));
+        $this->assertEquals('session.connect', $token->claims()->get('scope'));
+    }
+
     public function testStartsArchive(): void
     {
         // Arrange
@@ -763,7 +790,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -835,7 +862,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -874,7 +901,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -941,7 +968,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -987,7 +1014,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1029,7 +1056,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1074,7 +1101,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1118,7 +1145,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1161,7 +1188,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1200,7 +1227,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive/'.$archiveId.'/stop', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive/' . $archiveId . '/stop', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1236,7 +1263,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('GET', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive/'.$archiveId, $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive/' . $archiveId, $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1266,7 +1293,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('DELETE', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive/'.$archiveId, $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive/' . $archiveId, $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1300,7 +1327,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('GET', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1331,7 +1358,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('GET', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1366,7 +1393,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('GET', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1375,9 +1402,9 @@ class OpenTokTest extends TestCase
         $this->assertInstanceOf('OpenTok\ArchiveList', $archiveList);
         $this->assertEquals(2, $archiveList->totalCount());
         $this->assertEquals($sessionId, $archiveList->getItems()[0]->sessionId);
-        $this->assertEquals($sessionId, $archiveList->getItems()[1]->sessionId);        
+        $this->assertEquals($sessionId, $archiveList->getItems()[1]->sessionId);
         $this->assertEquals('b8f64de1-e218-4091-9544-4cbf369fc238', $archiveList->getItems()[0]->id);
-        $this->assertEquals('832641bf-5dbf-41a1-ad94-fea213e59a92', $archiveList->getItems()[1]->id);        
+        $this->assertEquals('832641bf-5dbf-41a1-ad94-fea213e59a92', $archiveList->getItems()[1]->id);
     }
 
     public function testFailsWhenListingArchivesWithTooLargeCount(): void
@@ -1440,7 +1467,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('DELETE', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/session/'.$sessionId.'/connection/'.$connectionId, $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/session/' . $sessionId . '/connection/' . $connectionId, $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1465,7 +1492,7 @@ class OpenTokTest extends TestCase
 
         $connectionId = '063e72a4-64b4-43c8-9da5-eca071daab89';
 
-        $this->expectException('OpenTok\Exception\ForceDisconnectConnectionException');        
+        $this->expectException('OpenTok\Exception\ForceDisconnectConnectionException');
 
         // Act
         $this->opentok->forceDisconnect($sessionId, $connectionId);
@@ -1526,202 +1553,202 @@ class OpenTokTest extends TestCase
         $this->assertEquals('7aebb3a4-3d86-4962-b317-afb73e05439d', $response['connectionId']);
     }
 
-	public function testCanStartBroadcastWithRmtp()
-	{
-		$this->setupOTWithMocks([[
-			'code' => 200,
-			'headers' => [
-				'Content-Type' => 'application/json'
-			],
-			'path' => '/v2/project/APIKEY/broadcast/BROADCASTID/start_default'
-		]]);
-
-		$sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
-
-		$options = [
-			'outputs' => [
-				'hls' => [
-					'dvr' => true,
-					'lowLatency' => false
-				],
-				'rtmp' => [
-					[
-						'id' => 'foo',
-						'serverUrl' => 'rtmps://myfooserver/myfooapp',
-						'streamName' => 'myfoostream'
-					],
-					[
-						'id' => 'bar',
-						'serverUrl' => 'rtmps://myfooserver/mybarapp',
-						'streamName' => 'mybarstream'
-					],
-				]
-			]
-		];
-
-		$broadcast = $this->opentok->startBroadcast($sessionId, $options);
-		$this->assertTrue($broadcast->isHls);
-		$this->assertFalse($broadcast->isDvr);
-		$this->assertFalse($broadcast->isLowLatency);
-		$this->assertTrue(array_key_exists('rtmp', $broadcast->broadcastUrls));
-	}
-
-	public function testCannotStartBroadcastWithOver5RtmpChannels(): void
-	{
-		$this->expectException(InvalidArgumentException::class);
-
-		$this->setupOTWithMocks([[
-			'code' => 200,
-			'headers' => [
-				'Content-Type' => 'application/json'
-			],
-			'path' => '/v2/project/APIKEY/broadcast/BROADCASTID/start_default'
-		]]);
-
-		$sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
-
-		$options = [
-			'outputs' => [
-				'hls' => [
-					'dvr' => true,
-					'lowLatency' => false
-				],
-				'rtmp' => [
-					[
-						'id' => 'one',
-						'serverUrl' => 'rtmps://myfooserver/one',
-						'streamName' => 'one'
-					],
-					[
-						'id' => 'two',
-						'serverUrl' => 'rtmps://myfooserver/two',
-						'streamName' => 'two'
-					],
-					[
-						'id' => 'three',
-						'serverUrl' => 'rtmps://myfooserver/three',
-						'streamName' => 'three'
-					],
-					[
-						'id' => 'four',
-						'serverUrl' => 'rtmps://myfooserver/four',
-						'streamName' => 'four'
-					],
-					[
-						'id' => 'five',
-						'serverUrl' => 'rtmps://myfooserver/five',
-						'streamName' => 'five'
-					],
-					[
-						'id' => 'six',
-						'serverUrl' => 'rtmps://myfooserver/six',
-						'streamName' => 'six'
-					],
-				]
-			]
-		];
-
-		$broadcast = $this->opentok->startBroadcast($sessionId, $options);
-	}
-
-	public function testCanStartBroadcastWithDefaultHlsOptions(): void
+    public function testCanStartBroadcastWithRmtp()
     {
-		$this->setupOTWithMocks([[
-			'code' => 200,
-			'headers' => [
-				'Content-Type' => 'application/json'
-			],
-			'path' => '/v2/project/APIKEY/broadcast/BROADCASTID/start_default'
-		]]);
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'path' => '/v2/project/APIKEY/broadcast/BROADCASTID/start_default'
+        ]]);
 
-		$sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
+        $sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
 
-		$broadcast = $this->opentok->startBroadcast($sessionId);
-		$this->assertTrue($broadcast->isHls);
-		$this->assertFalse($broadcast->isDvr);
-		$this->assertFalse($broadcast->isLowLatency);
+        $options = [
+            'outputs' => [
+                'hls' => [
+                    'dvr' => true,
+                    'lowLatency' => false
+                ],
+                'rtmp' => [
+                    [
+                        'id' => 'foo',
+                        'serverUrl' => 'rtmps://myfooserver/myfooapp',
+                        'streamName' => 'myfoostream'
+                    ],
+                    [
+                        'id' => 'bar',
+                        'serverUrl' => 'rtmps://myfooserver/mybarapp',
+                        'streamName' => 'mybarstream'
+                    ],
+                ]
+            ]
+        ];
+
+        $broadcast = $this->opentok->startBroadcast($sessionId, $options);
+        $this->assertTrue($broadcast->isHls);
+        $this->assertFalse($broadcast->isDvr);
+        $this->assertFalse($broadcast->isLowLatency);
+        $this->assertTrue(array_key_exists('rtmp', $broadcast->broadcastUrls));
+    }
+
+    public function testCannotStartBroadcastWithOver5RtmpChannels(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'path' => '/v2/project/APIKEY/broadcast/BROADCASTID/start_default'
+        ]]);
+
+        $sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
+
+        $options = [
+            'outputs' => [
+                'hls' => [
+                    'dvr' => true,
+                    'lowLatency' => false
+                ],
+                'rtmp' => [
+                    [
+                        'id' => 'one',
+                        'serverUrl' => 'rtmps://myfooserver/one',
+                        'streamName' => 'one'
+                    ],
+                    [
+                        'id' => 'two',
+                        'serverUrl' => 'rtmps://myfooserver/two',
+                        'streamName' => 'two'
+                    ],
+                    [
+                        'id' => 'three',
+                        'serverUrl' => 'rtmps://myfooserver/three',
+                        'streamName' => 'three'
+                    ],
+                    [
+                        'id' => 'four',
+                        'serverUrl' => 'rtmps://myfooserver/four',
+                        'streamName' => 'four'
+                    ],
+                    [
+                        'id' => 'five',
+                        'serverUrl' => 'rtmps://myfooserver/five',
+                        'streamName' => 'five'
+                    ],
+                    [
+                        'id' => 'six',
+                        'serverUrl' => 'rtmps://myfooserver/six',
+                        'streamName' => 'six'
+                    ],
+                ]
+            ]
+        ];
+
+        $broadcast = $this->opentok->startBroadcast($sessionId, $options);
+    }
+
+    public function testCanStartBroadcastWithDefaultHlsOptions(): void
+    {
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'path' => '/v2/project/APIKEY/broadcast/BROADCASTID/start_default'
+        ]]);
+
+        $sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
+
+        $broadcast = $this->opentok->startBroadcast($sessionId);
+        $this->assertTrue($broadcast->isHls);
+        $this->assertFalse($broadcast->isDvr);
+        $this->assertFalse($broadcast->isLowLatency);
         $this->assertEquals('live', $broadcast->broadcastUrls['rtmp']['foo']['status']);
-	}
+    }
 
-	public function testCanStartBroadcastWithDvrEnabled(): void
+    public function testCanStartBroadcastWithDvrEnabled(): void
     {
-		$this->setupOTWithMocks([[
-			'code' => 200,
-			'headers' => [
-				'Content-Type' => 'application/json'
-			],
-			'path' => '/v2/project/APIKEY/broadcast/BROADCASTID/start_dvr'
-		]]);
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'path' => '/v2/project/APIKEY/broadcast/BROADCASTID/start_dvr'
+        ]]);
 
-		$sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
+        $sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
 
-		$options = [
-			'outputs' => [
-				'hls' => [
-					'dvr' => true,
-					'lowLatency' => false
-				]
-			]
-		];
+        $options = [
+            'outputs' => [
+                'hls' => [
+                    'dvr' => true,
+                    'lowLatency' => false
+                ]
+            ]
+        ];
 
-		$broadcast = $this->opentok->startBroadcast($sessionId, $options);
-		$this->assertTrue($broadcast->isHls);
-		$this->assertTrue($broadcast->isDvr);
-		$this->assertFalse($broadcast->isLowLatency);
-	}
+        $broadcast = $this->opentok->startBroadcast($sessionId, $options);
+        $this->assertTrue($broadcast->isHls);
+        $this->assertTrue($broadcast->isDvr);
+        $this->assertFalse($broadcast->isLowLatency);
+    }
 
-	public function testCanStartBroadcastWithLowLatencyEnabled(): void
+    public function testCanStartBroadcastWithLowLatencyEnabled(): void
     {
-		$this->setupOTWithMocks([[
-			'code' => 200,
-			'headers' => [
-				'Content-Type' => 'application/json'
-			],
-			'path' => '/v2/project/APIKEY/broadcast/BROADCASTID/start_ll'
-		]]);
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'path' => '/v2/project/APIKEY/broadcast/BROADCASTID/start_ll'
+        ]]);
 
-		$sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
+        $sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
 
-		$options = [
-			'outputs' => [
-				'hls' => [
-					'dvr' => true,
-					'lowLatency' => false
-				]
-			]
-		];
+        $options = [
+            'outputs' => [
+                'hls' => [
+                    'dvr' => true,
+                    'lowLatency' => false
+                ]
+            ]
+        ];
 
-		$broadcast = $this->opentok->startBroadcast($sessionId, $options);
-		$this->assertTrue($broadcast->isHls);
-		$this->assertFalse($broadcast->isDvr);
-		$this->assertTrue($broadcast->isLowLatency);
-	}
+        $broadcast = $this->opentok->startBroadcast($sessionId, $options);
+        $this->assertTrue($broadcast->isHls);
+        $this->assertFalse($broadcast->isDvr);
+        $this->assertTrue($broadcast->isLowLatency);
+    }
 
-	public function testCannotStartBroadcastWithBothHlsAndDvrEnabled(): void
+    public function testCannotStartBroadcastWithBothHlsAndDvrEnabled(): void
     {
-		$this->expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
-		$this->setupOTWithMocks([[
-			'code' => 200,
-			'headers' => [
-				'Content-Type' => 'application/json'
-			],
-			'path' => '/v2/project/APIKEY/broadcast/BROADCASTID/start_ll'
-		]]);
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'path' => '/v2/project/APIKEY/broadcast/BROADCASTID/start_ll'
+        ]]);
 
-		$sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
+        $sessionId = '2_MX44NTQ1MTF-fjE0NzI0MzU2MDUyMjN-eVgwNFJhZmR6MjdockFHanpxNzBXaEFXfn4';
 
-		$options = [
-			'outputs' => [
-				'hls' => [
-					'dvr' => true,
-					'lowLatency' => true
-				]
-			]
-		];
+        $options = [
+            'outputs' => [
+                'hls' => [
+                    'dvr' => true,
+                    'lowLatency' => true
+                ]
+            ]
+        ];
 
-		$broadcast = $this->opentok->startBroadcast($sessionId, $options);
-	}
+        $broadcast = $this->opentok->startBroadcast($sessionId, $options);
+    }
 
     public function testStartsBroadcast(): void
     {
@@ -1741,7 +1768,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/broadcast', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/broadcast', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1806,7 +1833,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/broadcast', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/broadcast', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1871,7 +1898,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/broadcast', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/broadcast', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1923,7 +1950,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/broadcast', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/broadcast', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -1937,7 +1964,7 @@ class OpenTokTest extends TestCase
         $this->assertIsString($broadcast->id);
         $this->assertEquals($sessionId, $broadcast->sessionId);
         $this->assertEquals($maxDuration, $broadcast->maxDuration);
-        $this->assertEquals($resolution, $broadcast->resolution);        
+        $this->assertEquals($resolution, $broadcast->resolution);
         $this->assertIsArray($broadcast->broadcastUrls);
         $this->assertArrayHasKey('hls', $broadcast->broadcastUrls);
         $this->assertIsString($broadcast->broadcastUrls['hls']);
@@ -1968,7 +1995,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/broadcast/'.$broadcastId.'/stop', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/broadcast/' . $broadcastId . '/stop', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -2000,7 +2027,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('GET', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/broadcast/'.$broadcastId, $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/broadcast/' . $broadcastId, $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -2118,7 +2145,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('PUT', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/broadcast/'.$broadcastId.'/layout', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/broadcast/' . $broadcastId . '/layout', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -2158,7 +2185,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('PUT', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/broadcast/'.$broadcastId.'/layout', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/broadcast/' . $broadcastId . '/layout', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -2199,7 +2226,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('PUT', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/session/'.$sessionId.'/stream/'.$streamId, $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/session/' . $sessionId . '/stream/' . $streamId, $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -2231,11 +2258,11 @@ class OpenTokTest extends TestCase
         // Act
         $streamData = $this->opentok->getStream($sessionId, $streamId);
         // Assert
-        $this->assertCount(1, $this->historyContainer);        
+        $this->assertCount(1, $this->historyContainer);
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('GET', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/session/'.$sessionId.'/stream/'.$streamId, $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/session/' . $sessionId . '/stream/' . $streamId, $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -2576,7 +2603,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/session/'.$sessionId.'/signal', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/session/' . $sessionId . '/signal', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -2584,7 +2611,7 @@ class OpenTokTest extends TestCase
         $this->assertEquals(true, TestHelpers::validateOpenTokAuthHeader($this->API_KEY, $this->API_SECRET, $authString));
         $body = json_decode($request->getBody());
         $this->assertEquals('apple', $body->data);
-        $this->assertEquals('signal type sample', $body->type);        
+        $this->assertEquals('signal type sample', $body->type);
     }
 
     public function testSignalWithConnectionId(): void
@@ -2612,7 +2639,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('POST', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/session/'.$sessionId.'/connection/'.$connectionId.'/signal', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/session/' . $sessionId . '/connection/' . $connectionId . '/signal', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -2620,7 +2647,7 @@ class OpenTokTest extends TestCase
         $this->assertEquals(true, TestHelpers::validateOpenTokAuthHeader($this->API_KEY, $this->API_SECRET, $authString));
         $body = json_decode($request->getBody());
         $this->assertEquals('random message', $body->data);
-        $this->assertEquals('rest', $body->type);        
+        $this->assertEquals('rest', $body->type);
     }
 
     /**
@@ -2693,7 +2720,6 @@ class OpenTokTest extends TestCase
 
         // Act
         $this->opentok->signal($sessionId, $payload, $connectionId);
-
     }
 
     public function testListStreams(): void
@@ -2721,7 +2747,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('GET', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/session/'.$sessionId.'/stream/', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/session/' . $sessionId . '/stream/', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -2752,7 +2778,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('PUT', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive/'.$archiveId.'/layout', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive/' . $archiveId . '/layout', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -2792,7 +2818,7 @@ class OpenTokTest extends TestCase
 
         $request = $this->historyContainer[0]['request'];
         $this->assertEquals('PUT', strtoupper($request->getMethod()));
-        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive/'.$archiveId.'/layout', $request->getUri()->getPath());
+        $this->assertEquals('/v2/project/' . $this->API_KEY . '/archive/' . $archiveId . '/layout', $request->getUri()->getPath());
         $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
         $this->assertEquals('https', $request->getUri()->getScheme());
 
@@ -2899,4 +2925,3 @@ class OpenTokTest extends TestCase
         $this->assertTrue($result);
     }
 }
-

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -582,7 +582,7 @@ class OpenTokTest extends TestCase
         $opentok = new OpenTok($bogusApiKey, $bogusApiSecret);
 
         // Act
-        $token = $opentok->generateToken($sessionId);
+        $token = $opentok->generateToken($sessionId, [], true);
 
         // Assert
         $this->assertIsString($token);
@@ -613,7 +613,7 @@ class OpenTokTest extends TestCase
         $opentok = new OpenTok($bogusApiKey, $bogusApiSecret);
 
         // Act
-        $token = $opentok->generateToken($sessionId, array('role' => Role::MODERATOR));
+        $token = $opentok->generateToken($sessionId, array('role' => Role::MODERATOR), true);
 
         // Assert
         $this->assertIsString($token);
@@ -645,7 +645,7 @@ class OpenTokTest extends TestCase
         // Act
         // expires in one hour (60 seconds * 60 minutes)
         $inOneHour = time() + (60 * 60);
-        $token = $opentok->generateToken($sessionId, array('expireTime' => $inOneHour ));
+        $token = $opentok->generateToken($sessionId, array('expireTime' => $inOneHour ), true);
 
         // Assert
         $this->assertIsString($token);
@@ -675,7 +675,7 @@ class OpenTokTest extends TestCase
 
         // Act
         $userStatus = '{nick:"johnny",status:"hey there fellas!"}';
-        $token = $opentok->generateToken($sessionId, array('data' => $userStatus ));
+        $token = $opentok->generateToken($sessionId, array('data' => $userStatus), true);
 
         // Assert
         $this->assertIsString($token);
@@ -712,7 +712,7 @@ class OpenTokTest extends TestCase
         // Act
         $token = $opentok->generateToken($sessionId, array(
             'initialLayoutClassList' => $initialLayouClassList
-        ));
+        ), true);
 
         // Assert
         $this->assertIsString($token);
@@ -737,7 +737,7 @@ class OpenTokTest extends TestCase
     {
         $this->expectException('InvalidArgumentException');
         $this->setupOT();
-        $token = $this->opentok->generateToken('SESSIONID', array('role' => 'notarole'));
+        $token = $this->opentok->generateToken('SESSIONID', array('role' => 'notarole'), true);
     }
 
     public function testStartsArchive(): void

--- a/tests/OpenTokTest/SessionTest.php
+++ b/tests/OpenTokTest/SessionTest.php
@@ -156,7 +156,7 @@ class SessionTest extends TestCase
         $opentok = new OpenTok($bogusApiKey, $bogusApiSecret);
         $session = new Session($opentok, $sessionId);
 
-        $token = $session->generateToken();
+        $token = $session->generateToken([], true);
 
         $this->assertIsString($token);
         $decodedToken = TestHelpers::decodeToken($token);


### PR DESCRIPTION
T1 tokens are being marked as legacy to increase security. Instead, SHA256 encoded JWTs will be used by default.

## Description
generateToken() now takes a default parameter that is set to true unless specifically set by the user. To use the old T1 tokens for backwards compatibility, set the parameters like so:

```
$client = new OpenTok\OpenTok();
$token = $client->generateToken(API_KEY, API_SECRET, [], true);
```

## Motivation and Context
Increased security

## How Has This Been Tested?
Tests coming for the new tokens when exact setup of claims has been identified.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
