### PR TITLE
Added max bitrate and tests

### DIFF
--- a/src/OpenTok/Archive.php
+++ b/src/OpenTok/Archive.php
@@ -137,6 +137,7 @@ class Archive
         Validators::validateHasStreamMode($streamMode);
 
         $this->data = $archiveData;
+
         if (isset($this->data['multiArchiveTag'])) {
             $this->multiArchiveTag = $this->data['multiArchiveTag'];
         }
@@ -162,6 +163,7 @@ class Archive
         if ($this->isDeleted) {
             // TODO: throw an logic error about not being able to stop an archive thats deleted
         }
+
         switch ($name) {
             case 'createdAt':
             case 'duration':
@@ -178,6 +180,7 @@ class Archive
             case 'outputMode':
             case 'resolution':
             case 'streamMode':
+            case 'maxBitrate':
                 return $this->data[$name];
             case 'multiArchiveTag':
                 return $this->multiArchiveTag;

--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -502,8 +502,18 @@ class OpenTok
             'resolution' => null,
             'streamMode' => StreamMode::AUTO,
         );
+
+        // Horrible hack to workaround the defaults behaviour
+        if (isset($options['maxBitrate'])) {
+            $maxBitrate = $options['maxBitrate'];
+        }
+
         $options = array_merge($defaults, array_intersect_key($options, $defaults));
         list($name, $hasVideo, $hasAudio, $outputMode, $resolution, $streamMode) = array_values($options);
+
+        if (isset($maxBitrate)) {
+            $options['maxBitrate'] = $maxBitrate;
+        }
 
         Validators::validateSessionId($sessionId);
         Validators::validateArchiveName($name);

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -756,7 +756,7 @@ class OpenTokTest extends TestCase
         $sessionId = '2_MX44NTQ1MTF-flR1ZSBOb3YgMTIgMDk6NDA6NTkgUFNUIDIwMTN-MC43NjU0Nzh-';
 
         // Act
-        $archive = $this->opentok->startArchive($sessionId);
+        $archive = $this->opentok->startArchive($sessionId, ['maxBitrate' => 2000000]);
 
         // Assert
         $this->assertCount(1, $this->historyContainer);
@@ -779,6 +779,7 @@ class OpenTokTest extends TestCase
         $this->assertEquals('', $archive->reason);
         $this->assertEquals('started', $archive->status);
         $this->assertEquals(OutputMode::COMPOSED, $archive->outputMode);
+        $this->assertEquals(2000000, $archive->maxBitrate);
         $this->assertNull($archive->name);
         $this->assertNull($archive->url);
         $this->assertTrue($archive->hasVideo);
@@ -1246,7 +1247,38 @@ class OpenTokTest extends TestCase
         $this->assertEquals(true, TestHelpers::validateOpenTokAuthHeader($this->API_KEY, $this->API_SECRET, $authString));
 
         $this->assertInstanceOf('OpenTok\Archive', $archive);
-        // TODO: test the properties of the actual archive object
+    }
+
+    public function testGetsArchiveWithMaxBitrate(): void
+    {
+        // Arrange
+        $this->setupOTWithMocks([[
+            'code' => 200,
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'path' => 'v2/project/APIKEY/archive/ARCHIVEID/get'
+        ]]);
+
+        $archiveId = '063e72a4-64b4-43c8-9da5-eca071daab89';
+
+        // Act
+        $archive = $this->opentok->getArchive($archiveId);
+
+        // Assert
+        $this->assertCount(1, $this->historyContainer);
+
+        $request = $this->historyContainer[0]['request'];
+        $this->assertEquals('GET', strtoupper($request->getMethod()));
+        $this->assertEquals('/v2/project/'.$this->API_KEY.'/archive/'.$archiveId, $request->getUri()->getPath());
+        $this->assertEquals('api.opentok.com', $request->getUri()->getHost());
+        $this->assertEquals('https', $request->getUri()->getScheme());
+
+        $authString = $request->getHeaderLine('X-OPENTOK-AUTH');
+        $this->assertEquals(true, TestHelpers::validateOpenTokAuthHeader($this->API_KEY, $this->API_SECRET, $authString));
+
+        $this->assertInstanceOf('OpenTok\Archive', $archive);
+        $this->assertEquals(2000000, $archive->maxBitrate);
     }
 
     public function testDeletesArchive(): void

--- a/tests/mock/v2/project/APIKEY/archive/ARCHIVEID/get
+++ b/tests/mock/v2/project/APIKEY/archive/ARCHIVEID/get
@@ -3,6 +3,7 @@
   "duration" : 199,
   "id" : "063e72a4-64b4-43c8-9da5-eca071daab89",
   "name" : "showtime",
+  "maxBitrate": 2000000,
   "partnerId" : 854511,
   "reason" : "",
   "sessionId" : "2_MX44NTQ1MTF-flR1ZSBOb3YgMTIgMDk6NDA6NTkgUFNUIDIwMTN-MC43NjU0Nzh-",

--- a/tests/mock/v2/project/APIKEY/archive/session
+++ b/tests/mock/v2/project/APIKEY/archive/session
@@ -3,6 +3,7 @@
   "duration" : 0,
   "id" : "832641bf-5dbf-41a1-ad94-fea213e59a92",
   "name" : null,
+  "maxBitrate": 2000000,
   "partnerId" : 12345678,
   "reason" : "",
   "sessionId" : "2_MX44NTQ1MTF-flR1ZSBOb3YgMTIgMDk6NDA6NTkgUFNUIDIwMTN-MC43NjU0Nzh-",


### PR DESCRIPTION
This PR adds the ability to add a cap to the bitrate when starting an archive.

## Description
You can add maxBitrate within the `startArchive()` method when adding an options array.

```
$archive = $openTok->startArchive($sessionId, ['maxBitrate' => 2000000]);
```

## Motivation and Context
Parity with Video APIs

## How Has This Been Tested?
StartArchive test has been modified.

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
