### PR TITLE
sc-15922: upgrading actions/cache to 4.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
             - name: Cache Composer dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4.2.0
               with:
                 path: ${{ steps.composercache.outputs.dir }}
                 key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Because actions/cache is being deprecated below version 3, we are upgrading to version 4.2.0.

See: https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes for more info.

https://app.shortcut.com/amiqus/story/15923/repo-amiqus-auth0-assets-uses-actions-cache-v2
