### PR TITLE
Use firebase JWT

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": "^7.2|^8.0",
         "ext-xml": "*",
         "johnstevenson/json-works": "~1.1",
-        "firebase/php-jwt": "^6.0",
+        "firebase/php-jwt": "^6.11",
         "guzzlehttp/guzzle": "~6.0|~7.0",
       "ext-json": "*",
         "vonage/jwt": "^0.5.1"


### PR DESCRIPTION
This PR replaces the JWT library with the Firebase JWT PHP Library.

## Description
JWTs are now created with Firebase JWT PHP library by default, and use the new SHA256 algorithm instead of the older T1 tokens used by TokBox.

## Motivation and Context
Enhanced security.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
