### PR TITLE
fix: deprecated php 8.4 nullable default value

### DIFF
--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -1261,7 +1261,7 @@ class OpenTok
      *
      * @return void
      */
-    public function playDTMF(string $sessionId, string $digits, string $connectionId = null): void
+    public function playDTMF(string $sessionId, string $digits, ?string $connectionId = null): void
     {
         Validators::validateSessionIdBelongsToKey($sessionId, $this->apiKey);
         Validators::validateDTMFDigits($digits);

--- a/src/OpenTok/Util/Client.php
+++ b/src/OpenTok/Util/Client.php
@@ -753,7 +753,7 @@ class Client
         return $sipJson;
     }
 
-    public function playDTMF(string $sessionId, string $digits, string $connectionId = null): void
+    public function playDTMF(string $sessionId, string $digits, ?string $connectionId = null): void
     {
         $route = sprintf('/v2/project/%s/session/%s/play-dtmf', $this->apiKey, $sessionId);
         if ($connectionId) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix alterting deprecating 
```
OpenTok\OpenTok::playDTMF(): Implicitly marking parameter $connectionId as nullable is deprecated, the explicit nullable type must be used inste
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
