### PR TITLE
fix: Wrapped Vonage auth validators in try/catch

### DIFF
--- a/src/OpenTok/OpenTok.php
+++ b/src/OpenTok/OpenTok.php
@@ -52,8 +52,12 @@ class OpenTok
     {
         $apiUrl = 'https://api.opentok.com';
 
-        if (Validators::isVonageKeypair($apiKey, $apiSecret)) {
-            $apiUrl = 'https://video.api.vonage.com';
+        try {
+            if (Validators::isVonageKeypair($apiKey, $apiSecret)) {
+                $apiUrl = 'https://video.api.vonage.com';
+            }
+        } catch (InvalidArgumentException) {
+            // Not a Vonage Keypair, continue
         }
 
         // unpack optional arguments (merging with default values) into named variables
@@ -1404,5 +1408,10 @@ class OpenTok
     private function signString(string $string, $secret): string
     {
         return hash_hmac("sha1", $string, (string) $secret);
+    }
+
+    public function getClient(): Client
+    {
+        return $this->client;
     }
 }

--- a/tests/OpenTokTest/OpenTokTest.php
+++ b/tests/OpenTokTest/OpenTokTest.php
@@ -3419,4 +3419,24 @@ class OpenTokTest extends TestCase
 
         $this->opentok->connectAudio('9999', 'wrwetg', $badPayload);
     }
+
+    public function testCanCreateClientWithOpenTokCreds(): void
+    {
+        $client = new OpenTok('12345678', 'b60d0b2568f3ea9731bd9d3f71be263ce19f802f');
+        $this->assertInstanceOf(OpenTok::class, $client);
+    }
+
+    public function testCanCreateClientWithOpenTokCredsWithIntKey(): void
+    {
+        $client = new OpenTok(12345678, 'b60d0b2568f3ea9731bd9d3f71be263ce19f802f');
+        $this->assertInstanceOf(OpenTok::class, $client);
+    }
+
+    public function testCanCreateClientWithVonageCreds(): void
+    {
+        $key = file_get_contents(__DIR__ . '/test.key');
+        $client = new OpenTok('1ab38a10-ed9d-4e2b-8b14-95e52d76a13c', $key);
+        $this->assertInstanceOf(OpenTok::class, $client);
+        $this->assertEquals($client->getClient()->getApiSecret(), $key);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Wrapped Vonage auth validators in try/catch and added additional tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users that hardcode OT credentials with the ProjectID as integers caused validation to fail.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and some local testing

## Example Output or Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
